### PR TITLE
Build OSGi uberbundle instead of the uberjar

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -146,4 +146,16 @@
             </dependency>
         </dependencies>
     </dependencyManagement>
+
+    <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.apache.felix</groupId>
+                    <artifactId>maven-bundle-plugin</artifactId>
+                    <version>3.3.0</version>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+    </build>
 </project>

--- a/cli-activemq/pom.xml
+++ b/cli-activemq/pom.xml
@@ -31,8 +31,10 @@
     </parent>
 
     <artifactId>cli-activemq</artifactId>
+    <packaging>bundle</packaging>
 
     <properties>
+        <bundle.symbolic.name.suffix>aoc</bundle.symbolic.name.suffix>
         <jar.main.class>com.redhat.mqe.aoc.Main</jar.main.class>
         <activemq.client.version>LATEST</activemq.client.version>
         <library.version>${activemq.client.version}</library.version>

--- a/cli-artemis-jms/pom.xml
+++ b/cli-artemis-jms/pom.xml
@@ -31,8 +31,10 @@
     </parent>
 
     <artifactId>cli-artemis-jms</artifactId>
+    <packaging>bundle</packaging>
 
     <properties>
+        <bundle.symbolic.name.suffix>acc</bundle.symbolic.name.suffix>
         <jar.main.class>com.redhat.mqe.acc.Main</jar.main.class>
         <snapshots.enabled>false</snapshots.enabled>
         <artemis.jms.client.version>LATEST</artemis.jms.client.version>

--- a/cli-qpid-jms/pom.xml
+++ b/cli-qpid-jms/pom.xml
@@ -30,8 +30,10 @@
     </parent>
 
     <artifactId>cli-qpid-jms</artifactId>
+    <packaging>bundle</packaging>
 
     <properties>
+        <bundle.symbolic.name.suffix>jms</bundle.symbolic.name.suffix>
         <jar.main.class>com.redhat.mqe.jms.Main</jar.main.class>
         <qpid.jms.client.version>LATEST</qpid.jms.client.version>
         <library.version>${qpid.jms.client.version}</library.version>

--- a/jmslib/pom.xml
+++ b/jmslib/pom.xml
@@ -33,8 +33,7 @@
     <artifactId>jmslib</artifactId>
 
     <properties>
-        <!-- to create a jar with sensible name -->
-        <library.version></library.version>
+        <maven.install.skip>true</maven.install.skip>
     </properties>
 
     <dependencies>

--- a/jmslib/src/main/java/com/redhat/mqe/lib/Main.java
+++ b/jmslib/src/main/java/com/redhat/mqe/lib/Main.java
@@ -43,7 +43,14 @@ public class Main {
         if (client == null) {
             printHelpAndExit();
         } else {
-            client.startClient();
+            // https://stackoverflow.com/questions/2198928/better-handling-of-thread-context-classloader-in-osgi
+            ClassLoader originalClassLoader = Thread.currentThread().getContextClassLoader();
+            try {
+                Thread.currentThread().setContextClassLoader(Main.class.getClassLoader());
+                client.startClient();
+            } finally {
+                Thread.currentThread().setContextClassLoader(originalClassLoader);
+            }
         }
     }
 

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -221,8 +221,10 @@
                         <Bundle-SymbolicName>com.redhat.mqe.${bundle.symbolic.name.suffix}</Bundle-SymbolicName>
                         <Export-Package>com.redhat.mqe.${bundle.symbolic.name.suffix}</Export-Package>
                         <Import-Package></Import-Package>
+                        <DynamicImport-Package>*</DynamicImport-Package>
                         <Embed-Dependency>*;scope=compile|runtime;inline=true</Embed-Dependency>
                         <Embed-Transitive>true</Embed-Transitive>
+                        <Require-Capability>osgi.ee</Require-Capability>
                     </instructions>
                     <finalName>${jar.finalName}-${library.version}</finalName>
                 </configuration>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -34,10 +34,10 @@
     <packaging>pom</packaging>
 
     <properties>
+        <bundle.symbolic.name.suffix>Child POM responsibility</bundle.symbolic.name.suffix>
         <jar.main.class>Child POM responsibility</jar.main.class>
         <library.version>Child POM responsibility</library.version>
-        <buildNumber></buildNumber>
-        <jar.finalName>${project.artifactId}-${project.version}${buildNumber}</jar.finalName>
+        <jar.finalName>${project.artifactId}-${project.version}</jar.finalName>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
@@ -187,7 +187,7 @@
                 </configuration>
             </plugin>
             <plugin>
-                <!--Don't create default jar with no manifest etc -->
+                <!--Don't create default jar without dependencies -->
                 <artifactId>maven-jar-plugin</artifactId>
                 <version>${plugin.jar.version}</version>
                 <executions>
@@ -196,6 +196,36 @@
                         <phase>none</phase>
                     </execution>
                 </executions>
+                <configuration>
+                    <archive>
+                        <manifest>
+                            <mainClass>${jar.main.class}</mainClass>
+                        </manifest>
+                    </archive>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <extensions>true</extensions>
+                <!--https://issues.apache.org/jira/browse/FELIX-5698-->
+                <dependencies>
+                    <dependency>
+                        <groupId>biz.aQute.bnd</groupId>
+                        <artifactId>biz.aQute.bndlib</artifactId>
+                        <version>3.5.0</version>
+                    </dependency>
+                </dependencies>
+                <configuration>
+                    <instructions>
+                        <Bundle-SymbolicName>com.redhat.mqe.${bundle.symbolic.name.suffix}</Bundle-SymbolicName>
+                        <Export-Package>com.redhat.mqe.${bundle.symbolic.name.suffix}</Export-Package>
+                        <Import-Package></Import-Package>
+                        <Embed-Dependency>*;scope=compile|runtime;inline=true</Embed-Dependency>
+                        <Embed-Transitive>true</Embed-Transitive>
+                    </instructions>
+                    <finalName>${jar.finalName}-${library.version}</finalName>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -217,33 +247,6 @@
                     </execution>
                 </executions>
             </plugin>
-            <plugin>
-                <artifactId>maven-assembly-plugin</artifactId>
-                <version>${plugin.assembly.version}</version>
-                <configuration>
-                    <descriptorRefs>
-                        <descriptorRef>jar-with-dependencies</descriptorRef>
-                    </descriptorRefs>
-                    <archive>
-                        <manifest>
-                            <mainClass>${jar.main.class}</mainClass>
-                            <addClasspath>true</addClasspath>
-                        </manifest>
-                    </archive>
-                    <appendAssemblyId>false</appendAssemblyId>
-                    <finalName>${jar.finalName}-${library.version}</finalName>
-                </configuration>
-                <executions>
-                    <execution>
-                        <id>make-assembly</id>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>single</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -34,9 +34,9 @@
     <packaging>pom</packaging>
 
     <properties>
-        <bundle.symbolic.name.suffix>Child POM responsibility</bundle.symbolic.name.suffix>
-        <jar.main.class>Child POM responsibility</jar.main.class>
-        <library.version>Child POM responsibility</library.version>
+        <bundle.symbolic.name.suffix>ChildPomResponsibility</bundle.symbolic.name.suffix>
+        <jar.main.class>ChildPomResponsibility</jar.main.class>
+        <library.version>ChildPomResponsibility</library.version>
         <jar.finalName>${project.artifactId}-${project.version}</jar.finalName>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>


### PR DESCRIPTION
The bundle can be executed in the usual `java -jar` manner without using any OSGi.

When using OSGi, this gives us the separate classloader for each client.