### PR TITLE
Replace glassfish with jackson

### DIFF
--- a/jmslib/pom.xml
+++ b/jmslib/pom.xml
@@ -39,9 +39,9 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.glassfish</groupId>
-            <artifactId>javax.json</artifactId>
-            <version>1.1</version>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>2.9.2</version>
         </dependency>
 
         <!--scope provided means that it is a compileOnly dependency-->

--- a/jmslib/src/main/java/com/redhat/mqe/lib/MessageFormatter.java
+++ b/jmslib/src/main/java/com/redhat/mqe/lib/MessageFormatter.java
@@ -19,12 +19,12 @@
 
 package com.redhat.mqe.lib;
 
-import org.glassfish.json.JsonProviderImpl;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.jms.*;
-import javax.json.spi.JsonProvider;
 import java.io.UnsupportedEncodingException;
 import java.util.*;
 
@@ -47,7 +47,7 @@ public abstract class MessageFormatter {
     String JMSX_GROUP_ID = "JMSXGroupID";
 
     static Logger LOG = LoggerFactory.getLogger(MessageFormatter.class);
-    private JsonProvider json = new JsonProviderImpl();
+    private final ObjectMapper json = new ObjectMapper();
 
     /**
      * Print message body as text.
@@ -441,6 +441,10 @@ public abstract class MessageFormatter {
     }
 
     void printMessageAsJson(Map<String, Object> format) {
-        LOG.info(json.createObjectBuilder(format).build().toString());
+        try {
+            LOG.info(json.writeValueAsString(format));
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
     }
 }

--- a/tests/src/test/kotlin/AbstractMainTest.kt
+++ b/tests/src/test/kotlin/AbstractMainTest.kt
@@ -209,6 +209,20 @@ abstract class AbstractMainTest {
         }
     }
 
+    @Test
+    fun sendAndReceiveSingleMessageLogJsonFloatType() {
+        val senderParameters =
+            "sender --log-msgs dict --out json --broker $brokerUrl --address $address --msg-property baf~42.2 --count 1".split(" ").toTypedArray()
+        val receiverParameters =
+            "receiver --log-msgs dict --out json --broker $brokerUrl --address $address --count 1".split(" ").toTypedArray()
+        assertTimeoutPreemptively(Duration.ofSeconds(10)) {
+            print("Sending: ")
+            main(senderParameters)
+            print("Receiving: ")
+            main(receiverParameters)
+        }
+    }
+
     @ParameterizedTest
     @CsvFileSource(resources = arrayOf("/receiver.csv"))
     fun sendAndReceiveWithAllReceiverCLISwitches(receiverDynamicOptions: String) {

--- a/tests/src/test/kotlin/com/redhat/mqe/lib/AbstractMessageFormatterTest.kt
+++ b/tests/src/test/kotlin/com/redhat/mqe/lib/AbstractMessageFormatterTest.kt
@@ -23,13 +23,8 @@ import com.google.common.truth.Truth.assertThat
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.function.Executable
-import java.security.InvalidParameterException
-import java.util.*
 import javax.jms.BytesMessage
 import javax.jms.Message
-import javax.json.Json
-import javax.json.JsonValue
-import javax.json.spi.JsonProvider
 
 class Formatter : MessageFormatter() {
     override fun formatMessage(msg: Message?): MutableMap<String, Any> {


### PR DESCRIPTION
Glassfish is unable to encode a java.lang.Float type
to JSON. This seems trivial omission in the library,
easy to fix... Bug could be raised.

Jackson can encode it just fine. Seems a better choice.

This fixes #27