### PR TITLE
Write all logs (except messages) to System.err

### DIFF
--- a/cli-activemq/src/main/resources/log4j.properties
+++ b/cli-activemq/src/main/resources/log4j.properties
@@ -39,6 +39,7 @@ log4j.logger.netty=WARN, console
 
 # Appender "console" settings
 log4j.appender.console=org.apache.log4j.ConsoleAppender
+log4j.appender.console.target=System.err
 log4j.appender.console.Threshold=all
 log4j.appender.console.layout=org.apache.log4j.PatternLayout
 #log4j.appender.console.layout.ConversionPattern=%t %d %p [%c{4}] %m%n

--- a/cli-artemis-jms/src/main/resources/log4j.properties
+++ b/cli-artemis-jms/src/main/resources/log4j.properties
@@ -39,6 +39,7 @@ log4j.logger.netty=WARN, console
 
 # Appender "console" settings
 log4j.appender.console=org.apache.log4j.ConsoleAppender
+log4j.appender.console.target=System.err
 log4j.appender.console.Threshold=all
 log4j.appender.console.layout=org.apache.log4j.PatternLayout
 #log4j.appender.console.layout.ConversionPattern=%t %d %p [%c{4}] %m%n

--- a/cli-qpid-jms/src/main/resources/log4j.properties
+++ b/cli-qpid-jms/src/main/resources/log4j.properties
@@ -43,6 +43,7 @@ log4j.logger.org.apache.qpid.jms.transports.netty.NettyTcpTransport=DEBUG, conso
 
 # Appender "console" settings
 log4j.appender.console=org.apache.log4j.ConsoleAppender
+log4j.appender.console.target=System.err
 log4j.appender.console.Threshold=all
 log4j.appender.console.layout=org.apache.log4j.PatternLayout
 #log4j.appender.console.layout.ConversionPattern=%t %d %p [%c{4}] %m%n


### PR DESCRIPTION
PN_TRACE_FRM is still enabled through env variable and goes to stdout in qpid-jms.

This closes #41