### PR TITLE
Add standalone demonstration of QPIDJMS-357 individual ack as a test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ script:
   - docker pull jdanekrh/docker-alpine-openjdk-artemis-snapshot
   - docker run --rm -v`pwd`/scripts:/mnt -p 5672:5672 -p 61616:61616 -p 5673:5673 -p 61617:61617 --entrypoint ash jdanekrh/docker-alpine-openjdk-artemis-snapshot /mnt/entrypoint.sh amq7-server &
   - sleep 10
-  - mvn clean package
+  - mvn clean package -Ptests
 
   - java -jar cli-activemq/target/cli-activemq-1.2.2-SNAPSHOT-LATEST.jar sender --address cli-activemq --log-msgs json --count 1
   - java -jar cli-activemq/target/cli-activemq-1.2.2-SNAPSHOT-LATEST.jar receiver --address cli-activemq --log-msgs json --count 1

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -43,7 +43,7 @@
         <plugin.jar.version>3.0.2</plugin.jar.version>
         <plugin.jacoco.version>0.8.1</plugin.jacoco.version>
         <plugin.bundle.version>3.5.0</plugin.bundle.version>
-        <plugin.surefire.version>2.21.0</plugin.surefire.version>
+        <plugin.surefire.version>2.19.1</plugin.surefire.version>
     </properties>
     <dependencyManagement>
         <dependencies>

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -41,7 +41,7 @@
         <plugin.assembly.version>3.1.0</plugin.assembly.version>
         <plugin.enforcer.version>3.0.0-M1</plugin.enforcer.version>
         <plugin.jar.version>3.0.2</plugin.jar.version>
-        <plugin.jacoco.version>0.8.1</plugin.jacoco.version>
+        <plugin.jacoco.version>0.8.0</plugin.jacoco.version>
         <plugin.bundle.version>3.5.0</plugin.bundle.version>
         <plugin.surefire.version>2.19.1</plugin.surefire.version>
     </properties>

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -33,7 +33,6 @@
         <dagger.version>2.15</dagger.version>
 
         <kotlin.version>1.2.21</kotlin.version>
-        <junit.version>4.12</junit.version>
         <junit.jupiter.version>5.2.0-RC1</junit.jupiter.version>
         <junit.platform.version>1.2.0-RC1</junit.platform.version>
         <truth.version>0.40</truth.version>
@@ -126,12 +125,6 @@
                 <groupId>org.junit.jupiter</groupId>
                 <artifactId>junit-jupiter-api</artifactId>
                 <version>${junit.jupiter.version}</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>junit</groupId>
-                <artifactId>junit</artifactId>
-                <version>${junit.version}</version>
                 <scope>test</scope>
             </dependency>
             <dependency>

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -33,8 +33,8 @@
         <dagger.version>2.15</dagger.version>
 
         <kotlin.version>1.2.21</kotlin.version>
-        <junit.jupiter.version>5.2.0-RC1</junit.jupiter.version>
-        <junit.platform.version>1.2.0-RC1</junit.platform.version>
+        <junit.jupiter.version>5.1.1</junit.jupiter.version>
+        <junit.platform.version>1.1.1</junit.platform.version>
         <truth.version>0.40</truth.version>
 
         <plugin.compiler.version>3.7.0</plugin.compiler.version>

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -27,25 +27,6 @@
     <version>1.2.2-SNAPSHOT</version>
     <packaging>pom</packaging>
 
-    <repositories>
-        <repository>
-            <id>junit5-SNAPSHOT</id>
-            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-            <snapshots>
-                <enabled>true</enabled>
-            </snapshots>
-        </repository>
-    </repositories>
-    <pluginRepositories>
-        <pluginRepository>
-            <id>junit5-SNAPSHOT</id>
-            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-            <snapshots>
-                <enabled>true</enabled>
-            </snapshots>
-        </pluginRepository>
-    </pluginRepositories>
-
     <properties>
         <slfj.version>1.7.25</slfj.version>
         <jopt.version>4.9</jopt.version>
@@ -53,8 +34,8 @@
 
         <kotlin.version>1.2.21</kotlin.version>
         <junit.version>4.12</junit.version>
-        <junit.jupiter.version>5.2.0-SNAPSHOT</junit.jupiter.version>
-        <junit.platform.version>1.2.0-SNAPSHOT</junit.platform.version>
+        <junit.jupiter.version>5.2.0-RC1</junit.jupiter.version>
+        <junit.platform.version>1.2.0-RC1</junit.platform.version>
         <truth.version>0.40</truth.version>
 
         <plugin.compiler.version>3.7.0</plugin.compiler.version>

--- a/cli-qpid-jms/src/test/kotlin/QPIDJMS357Test.kt
+++ b/cli-qpid-jms/src/test/kotlin/QPIDJMS357Test.kt
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) 2018 Red Hat, Inc.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.math.BigInteger
+import java.util.*
+import javax.jms.Connection
+import javax.jms.ConnectionFactory
+import javax.jms.Session
+
+class QPIDJMS357Test {
+    val prefix: String = "QPIDJMS357Test_"
+    lateinit var randomSuffix: String
+    val address: String
+        get() = prefix + randomSuffix
+
+    val random = Random()
+
+    @BeforeEach
+    fun setUp() {
+        // https://stackoverflow.com/questions/41107/how-to-generate-a-random-alpha-numeric-string
+        randomSuffix = BigInteger(130, random).toString(32)
+    }
+
+    class Client {
+        val INDIVIDUAL_ACKNOWLEDGE = 101
+
+        lateinit var f: ConnectionFactory
+        lateinit var c: Connection
+        lateinit var s: Session
+
+        fun start() {
+            f = org.apache.qpid.jms.JmsConnectionFactory(
+                "amqp://127.0.0.1:5672")
+            c = f.createConnection()
+            c.start()
+            s = c.createSession(false, INDIVIDUAL_ACKNOWLEDGE)
+        }
+
+        fun stop() {
+            s.close()
+            c.stop()
+            c.close()
+        }
+    }
+
+    @Test
+    fun `acknowledge can be switched to individual mode`() {
+        val client1 = Client()
+        client1.start()
+        client1.apply {
+            val queue = s.createQueue(address)
+            println(queue)
+            val producer = s.createProducer(queue)
+            for (i in 1..3) {
+                println(i)
+                val m = s.createMessage()
+                m.setIntProperty("i", i)
+                producer.send(m)
+            }
+        }
+        client1.stop()
+
+        Thread.sleep(1000)
+
+        val client2 = Client()
+        client2.start()
+        client2.apply {
+            val queue = s.createQueue(address)
+            println(queue)
+            // leave first message unacknowledged, do not receive third
+            val consumer1 = s.createConsumer(queue)
+            val m11 = consumer1.receive(2000)
+            val m12 = consumer1.receive(2000)
+            s.setMessageListener { }
+            m12.acknowledge()
+            consumer1.close()
+        }
+        client2.stop()
+
+        val client3 = Client()
+        client3.start()
+        client3.apply {
+            val queue = s.createQueue(address)
+            // now receive both the first and third message
+            val consumer2 = s.createConsumer(queue)
+            val m21 = consumer2.receive(2000)
+            val m23 = consumer2.receive(2000)
+            m21.acknowledge()
+            m23.acknowledge()
+            consumer2.close()
+
+            assertThat(m21.getIntProperty("i")).isEqualTo(1)
+            assertThat(m23.getIntProperty("i")).isEqualTo(3)
+        }
+        client3.stop()
+    }
+}

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -157,6 +157,7 @@
                 <version>${plugin.surefire.version}</version>
                 <configuration>
                     <trimStackTrace>false</trimStackTrace>
+                    <forkCount>0</forkCount>
                 </configuration>
                 <dependencies>
                     <dependency>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -116,10 +116,12 @@
 
     <profiles>
         <profile>
-            <!--build tests only on java 8 and up-->
-            <id>java8</id>
+            <!--build Kotlin tests only when explicitly requested-->
+            <id>tests</id>
             <activation>
-                <jdk>(1.7,)</jdk>
+                <property>
+                    <name>tests</name>
+                </property>
             </activation>
             <build>
                 <plugins>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -152,7 +152,7 @@
                 <version>${plugin.surefire.version}</version>
                 <configuration>
                     <trimStackTrace>false</trimStackTrace>
-                    <forkCount>0</forkCount>
+                    <forkCount>1</forkCount>
                 </configuration>
                 <dependencies>
                     <dependency>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -248,6 +248,7 @@
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
+                <version>${plugin.jacoco.version}</version>
                 <executions>
                     <execution>
                         <goals>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -153,6 +153,9 @@
                 <configuration>
                     <trimStackTrace>false</trimStackTrace>
                     <forkCount>1</forkCount>
+                    <properties>
+                        <excludeTags>pairwise</excludeTags>
+                    </properties>
                 </configuration>
                 <dependencies>
                     <dependency>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -248,7 +248,6 @@
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <version>${plugin.jacoco.version}</version>
                 <executions>
                     <execution>
                         <goals>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -76,11 +76,6 @@
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-params</artifactId>
         </dependency>
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <scope>test</scope>
-        </dependency>
 
         <!-- Only required to run tests in an IntelliJ IDEA that bundles an older version -->
         <dependency>

--- a/tests/src/test/kotlin/AbstractMainTest.kt
+++ b/tests/src/test/kotlin/AbstractMainTest.kt
@@ -20,6 +20,7 @@
 import com.google.common.truth.Truth.assertThat
 import org.junit.jupiter.api.Assertions.assertTimeoutPreemptively
 import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.function.Executable
 import org.junit.jupiter.params.ParameterizedTest
@@ -97,6 +98,7 @@ abstract class AbstractMainTest {
         randomSuffix = BigInteger(130, random).toString(32)
     }
 
+    @Tag("pairwise")
     @ParameterizedTest
     @ValueSource(strings = arrayOf("sender", "receiver", "connector"))
     fun printHelp(client: String) {
@@ -255,6 +257,7 @@ abstract class AbstractMainTest {
         }
     }
 
+    @Tag("pairwise")
     @ParameterizedTest
     @CsvFileSource(resources = arrayOf("/sender.csv"))
     fun sendAndReceiveWithAllSenderCLISwitches(senderDynamicOptions: String) {
@@ -272,6 +275,7 @@ abstract class AbstractMainTest {
         }
     }
 
+    @Tag("pairwise")
     @ParameterizedTest
     @CsvFileSource(resources = arrayOf("/connector.csv"))
     fun connectConnectorWithAllSenderCLISwitches(senderDynamicOptions: String) {


### PR DESCRIPTION
Other commits deal with messing with dependency versions. Final solution seems to be to downgrade to surefire 2.19.1, which is what everybody out on the net is using, given all the issues. Also, I do not want any SNAPSHOTs or RCs, because that just looks unprofessional. I do not want any problems with this.