### PR TITLE
Close connection if browsing fails, otherwise the client hangs

### DIFF
--- a/jmslib/src/main/java/com/redhat/mqe/lib/MessageBrowser.java
+++ b/jmslib/src/main/java/com/redhat/mqe/lib/MessageBrowser.java
@@ -71,14 +71,17 @@ public class MessageBrowser extends CoreClient {
      */
     void browseMessages() throws Exception {
         Connection conn = createConnection(clientOptions);
-        Session ssn = createSession(clientOptions, conn, transacted);
-        QueueBrowser qBrowser = ssn.createBrowser((Queue) getDestination(), msgSelector);
-        conn.start();
-        Enumeration<?> enumMsgs = qBrowser.getEnumeration();
-        while (enumMsgs.hasMoreElements()) {
-            Message msg = (Message) enumMsgs.nextElement();
-            printMessage(clientOptions, msg);
+        try {
+            Session ssn = createSession(clientOptions, conn, transacted);
+            QueueBrowser qBrowser = ssn.createBrowser((Queue) getDestination(), msgSelector);
+            conn.start();
+            Enumeration<?> enumMsgs = qBrowser.getEnumeration();
+            while (enumMsgs.hasMoreElements()) {
+                Message msg = (Message) enumMsgs.nextElement();
+                printMessage(clientOptions, msg);
+            }
+        } finally {
+            close(conn);
         }
-        close(conn);
     }
 }


### PR DESCRIPTION
## Testing

# artemis-users.properties
nobody = nobody

$ java -jar /var/dtests/node_data/clients/aac1.jar receiver -b 10.37.145.206:61616 --address "example::example" --log-msgs dict --conn-username nobody -conn-password nobody --recv-browse false
[...] Exception in thread "main" com.redhat.mqe.lib.JmsMessagingException: unable to browse messages