### PR TITLE
Workaround for dagger/guava/artemis-commons incompatibility

### DIFF
--- a/cli-artemis-jms/pom.xml
+++ b/cli-artemis-jms/pom.xml
@@ -61,6 +61,17 @@
             <artifactId>artemis-commons</artifactId>
             <version>${artemis.jms.client.version}</version>
         </dependency>
+        <!--workaround for dagger/guava/artemis-commons incompatibility-->
+        <!--solution inspired by:-->
+        <!--https://stackoverflow.com/questions/49928077/fluentfuture-class-not-found-with-multiple-anntationprocessor-->
+        <!--https://github.com/google/guava/issues/2837-->
+        <!--https://github.com/google/guava/issues/2721#issuecomment-275220035-->
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>23.4-android</version>
+            <scope>provided</scope>
+        </dependency>
 
         <dependency>
             <groupId>com.redhat.cli-java</groupId>


### PR DESCRIPTION
This appears with downstream builds, in upstream it is not present
probably thanks to https://issues.apache.org/jira/browse/ARTEMIS-1783 work.