### PR TITLE
Mt client failover

### DIFF
--- a/cli-activemq/src/main/java/com/redhat/mqe/aoc/AocClientOptionManager.java
+++ b/cli-activemq/src/main/java/com/redhat/mqe/aoc/AocClientOptionManager.java
@@ -128,9 +128,11 @@ class AocClientOptionManager extends ClientOptionManager {
         if (uriProtocol != null) {
             checkAndSetOption(ClientOptions.PROTOCOL, uriProtocol, clientOptions);
             // Set the whole url as failoverUrl. Do not parse it. connection options should come as input "conn-*"
-            //TODO if missing protocol, add amqp by default
+
             // failover:(dhcp-75-212.lab.eng.brq.redhat.com:5672,dhcp-75-219.lab.eng.brq.redhat.com:5672) -->
             // failover:(tcp://dhcp-75-212.lab.eng.brq.redhat.com:5672,tcp://dhcp-75-219.lab.eng.brq.redhat.com:5672) -->
+            // TODO discovery..
+            // discovery:(tcp://dhcp-75-212.lab.eng.brq.redhat.com:5672,tcp://dhcp-75-219.lab.eng.brq.redhat.com:5672) -->
             brokerUrl = appendMissingProtocol(brokerUrl);
 
             // If Failover-url list contains a broker value, add it here

--- a/cli-activemq/src/main/java/com/redhat/mqe/aoc/AocClientOptionManager.java
+++ b/cli-activemq/src/main/java/com/redhat/mqe/aoc/AocClientOptionManager.java
@@ -132,6 +132,19 @@ class AocClientOptionManager extends ClientOptionManager {
             // failover:(dhcp-75-212.lab.eng.brq.redhat.com:5672,dhcp-75-219.lab.eng.brq.redhat.com:5672) -->
             // failover:(tcp://dhcp-75-212.lab.eng.brq.redhat.com:5672,tcp://dhcp-75-219.lab.eng.brq.redhat.com:5672) -->
             brokerUrl = appendMissingProtocol(brokerUrl);
+
+            // If Failover-url list contains a broker value, add it here
+            if (clientOptions.getOption(ClientOptions.CON_FAILOVER_URLS).hasParsedValue()) {
+                StringBuilder failoverBrokers = new StringBuilder(",");
+                String reconnectBrokers = clientOptions.getOption(ClientOptions.CON_FAILOVER_URLS).getValue();
+
+                for (String brokerFailover : reconnectBrokers.split(",")) {
+                    failoverBrokers.append(appendMissingProtocol(brokerFailover)).append(",");
+                }
+                failoverBrokers.deleteCharAt(failoverBrokers.length() - 1);
+                brokerUrl += failoverBrokers;
+            }
+
             checkAndSetOption(ClientOptions.FAILOVER_URL, brokerUrl, clientOptions);
         } else {
             super.setBrokerOptions(clientOptions, brokerUrl);

--- a/cli-artemis-jms/src/main/java/com/redhat/mqe/acc/AccClientOptionManager.java
+++ b/cli-artemis-jms/src/main/java/com/redhat/mqe/acc/AccClientOptionManager.java
@@ -142,20 +142,11 @@ class AccClientOptionManager extends ClientOptionManager {
 
     @Override
     protected void setBrokerOptions(ClientOptions clientOptions, String brokerUrl) {
-        // Intercept setBrokerOptions and configure reconnect for the Aoc client
-
-        String uriProtocol = null;
+        String brokerUrlTmp = brokerUrl;
         if (Boolean.parseBoolean(clientOptions.getOption(ClientOptions.CON_RECONNECT).getValue())) {
-            // use failover mechanism by default, discovery otherwise
-//            uriProtocol = "tcp";
-//        }
-//        if (uriProtocol != null) {
-//            checkAndSetOption(ClientOptions.PROTOCOL, uriProtocol, clientOptions);
-            // Set the whole url as failoverUrl. Do not parse it. connection options should come as input "conn-*"
-            //TODO if missing protocol, add amqp by default
-            // failover:(dhcp-75-212.lab.eng.brq.redhat.com:5672,dhcp-75-219.lab.eng.brq.redhat.com:5672) -->
-            // failover:(tcp://dhcp-75-212.lab.eng.brq.redhat.com:5672,tcp://dhcp-75-219.lab.eng.brq.redhat.com:5672) -->
-            brokerUrl = appendMissingProtocol(brokerUrl);
+            // use failover mechanism if provided in conn-urls, use discovery by default
+            // (tcp://dhcp-75-212.lab.eng.brq.redhat.com:5672,tcp://dhcp-75-219.lab.eng.brq.redhat.com:5672)
+            brokerUrlTmp = appendMissingProtocol(brokerUrl);
 
             // If Failover-url list contains a broker value, add it here
             if (clientOptions.getOption(ClientOptions.CON_FAILOVER_URLS).hasParsedValue()) {
@@ -166,13 +157,13 @@ class AccClientOptionManager extends ClientOptionManager {
                     failoverBrokers.append(appendMissingProtocol(brokerFailover)).append(",");
                 }
                 failoverBrokers.deleteCharAt(failoverBrokers.length() - 1);
-                brokerUrl += failoverBrokers;
+                brokerUrlTmp += failoverBrokers;
             }
-            checkAndSetOption(ClientOptions.FAILOVER_URL, brokerUrl, clientOptions);
+            checkAndSetOption(ClientOptions.FAILOVER_URL, brokerUrlTmp, clientOptions);
             // use empty protocol as "main"
             checkAndSetOption(ClientOptions.PROTOCOL, "", clientOptions);
         } else {
-            super.setBrokerOptions(clientOptions, brokerUrl);
+            super.setBrokerOptions(clientOptions, brokerUrlTmp);
         }
     }
 

--- a/cli-artemis-jms/src/main/java/com/redhat/mqe/acc/AccClientOptionManager.java
+++ b/cli-artemis-jms/src/main/java/com/redhat/mqe/acc/AccClientOptionManager.java
@@ -141,6 +141,42 @@ class AccClientOptionManager extends ClientOptionManager {
     }
 
     @Override
+    protected void setBrokerOptions(ClientOptions clientOptions, String brokerUrl) {
+        // Intercept setBrokerOptions and configure reconnect for the Aoc client
+
+        String uriProtocol = null;
+        if (Boolean.parseBoolean(clientOptions.getOption(ClientOptions.CON_RECONNECT).getValue())) {
+            // use failover mechanism by default, discovery otherwise
+//            uriProtocol = "tcp";
+//        }
+//        if (uriProtocol != null) {
+//            checkAndSetOption(ClientOptions.PROTOCOL, uriProtocol, clientOptions);
+            // Set the whole url as failoverUrl. Do not parse it. connection options should come as input "conn-*"
+            //TODO if missing protocol, add amqp by default
+            // failover:(dhcp-75-212.lab.eng.brq.redhat.com:5672,dhcp-75-219.lab.eng.brq.redhat.com:5672) -->
+            // failover:(tcp://dhcp-75-212.lab.eng.brq.redhat.com:5672,tcp://dhcp-75-219.lab.eng.brq.redhat.com:5672) -->
+            brokerUrl = appendMissingProtocol(brokerUrl);
+
+            // If Failover-url list contains a broker value, add it here
+            if (clientOptions.getOption(ClientOptions.CON_FAILOVER_URLS).hasParsedValue()) {
+                StringBuilder failoverBrokers = new StringBuilder(",");
+                String reconnectBrokers = clientOptions.getOption(ClientOptions.CON_FAILOVER_URLS).getValue();
+
+                for (String brokerFailover : reconnectBrokers.split(",")) {
+                    failoverBrokers.append(appendMissingProtocol(brokerFailover)).append(",");
+                }
+                failoverBrokers.deleteCharAt(failoverBrokers.length() - 1);
+                brokerUrl += failoverBrokers;
+            }
+            checkAndSetOption(ClientOptions.FAILOVER_URL, brokerUrl, clientOptions);
+            // use empty protocol as "main"
+            checkAndSetOption(ClientOptions.PROTOCOL, "", clientOptions);
+        } else {
+            super.setBrokerOptions(clientOptions, brokerUrl);
+        }
+    }
+
+    @Override
     protected String getUrlProtocol() {
         return "tcp";
     }

--- a/cli-artemis-jms/src/main/java/com/redhat/mqe/acc/AccConnectionManager.java
+++ b/cli-artemis-jms/src/main/java/com/redhat/mqe/acc/AccConnectionManager.java
@@ -64,6 +64,7 @@ public class AccConnectionManager extends ConnectionManager {
 ////                destination = (Destination) initialContext.lookup(this.queueOrTopic);
             }
 
+            LOG.debug("Connection=" + brokerUrl);
             LOG.trace("Destination=" + destination);
             if (clientOptions.getOption(ClientOptions.BROKER_URI).hasParsedValue() || (username == null && password == null)) {
                 connection = factory.createConnection();

--- a/cli-artemis-jms/src/main/java/com/redhat/mqe/acc/AccConnectionManager.java
+++ b/cli-artemis-jms/src/main/java/com/redhat/mqe/acc/AccConnectionManager.java
@@ -88,7 +88,6 @@ public class AccConnectionManager extends ConnectionManager {
         } catch (JMSException e) {
             LOG.error(e.getMessage());
             e.printStackTrace();
-            System.exit(1);
         }
     }
 

--- a/cli-qpid-jms/src/main/java/com/redhat/mqe/jms/AacClientOptionManager.java
+++ b/cli-qpid-jms/src/main/java/com/redhat/mqe/jms/AacClientOptionManager.java
@@ -114,9 +114,9 @@ public class AacClientOptionManager extends ClientOptionManager {
         if (uriProtocol != null) {
             checkAndSetOption(ClientOptions.PROTOCOL, uriProtocol, clientOptions);
             // Set the whole url as failoverUrl. Do not parse it. connection options should come as input "conn-*"
-            //TODO if missing protocol, add amqp by default
             // failover:(dhcp-75-212.lab.eng.brq.redhat.com:5672,dhcp-75-219.lab.eng.brq.redhat.com:5672) -->
             // failover:(tcp://dhcp-75-212.lab.eng.brq.redhat.com:5672,tcp://dhcp-75-219.lab.eng.brq.redhat.com:5672) -->
+            // TODO discovery protocol (should work by default in AMQP client)
             brokerUrl = appendMissingProtocol(brokerUrl);
 
             // If Failover-url list contains a broker value, add it here

--- a/cli-qpid-jms/src/main/java/com/redhat/mqe/jms/AacClientOptions.java
+++ b/cli-qpid-jms/src/main/java/com/redhat/mqe/jms/AacClientOptions.java
@@ -263,6 +263,7 @@ public abstract class AacClientOptions extends ClientOptions {
                 "the number of attempts made to connect before reporting the connection as failed. The default is value of maxReconnectAttempts"),
             new Option(CON_RECONNECT_INITIAL_DELAY, "", "DELAY", "0", "delay the client will wait before the first attempt to reconnect to a remote peer"),
             new Option(CON_RECONNECT_WARN_ATTEMPTS, "", "ATTEMPTS", "10", "that often the client will log a message indicating that failover reconnection is being attempted"),
+            new Option(CON_RECONNECT_URL, "", "BROKER_URL", "", "additional brokers to add to broker-url as CSV"),
 
             new Option(CON_SSL_KEYSTORE_LOC, "", "LOC", "", "default is to read from the system property \"javax.net.ssl.keyStore\""),
             new Option(CON_SSL_KEYSTORE_PASS, "", "PASS", "", "default is to read from the system property \"javax.net.ssl.keyStorePassword\""),

--- a/cli-qpid-jms/src/main/java/com/redhat/mqe/jms/AacClientOptions.java
+++ b/cli-qpid-jms/src/main/java/com/redhat/mqe/jms/AacClientOptions.java
@@ -263,7 +263,7 @@ public abstract class AacClientOptions extends ClientOptions {
                 "the number of attempts made to connect before reporting the connection as failed. The default is value of maxReconnectAttempts"),
             new Option(CON_RECONNECT_INITIAL_DELAY, "", "DELAY", "0", "delay the client will wait before the first attempt to reconnect to a remote peer"),
             new Option(CON_RECONNECT_WARN_ATTEMPTS, "", "ATTEMPTS", "10", "that often the client will log a message indicating that failover reconnection is being attempted"),
-            new Option(CON_RECONNECT_URL, "", "BROKER_URL", "", "additional brokers to add to broker-url as CSV"),
+            new Option(CON_FAILOVER_URLS, "", "BROKER_URL", "", "additional brokers to add to broker-url as CSV"),
 
             new Option(CON_SSL_KEYSTORE_LOC, "", "LOC", "", "default is to read from the system property \"javax.net.ssl.keyStore\""),
             new Option(CON_SSL_KEYSTORE_PASS, "", "PASS", "", "default is to read from the system property \"javax.net.ssl.keyStorePassword\""),

--- a/jmslib/src/main/java/com/redhat/mqe/lib/ClientOptionManager.java
+++ b/jmslib/src/main/java/com/redhat/mqe/lib/ClientOptionManager.java
@@ -401,6 +401,10 @@ public abstract class ClientOptionManager {
                 // use failover mechanism, conn-reconnect does not perform nor add any other action to the client
                 return;
             }
+            if (option.getName().equals(ClientOptions.CON_FAILOVER_URLS)) {
+                // add CSV of broker urls failover mechanism, conn-reconnect
+                return;
+            }
             LOG.error("Connection option {} is not recognized! ", option.getName());
             System.exit(2);
         }

--- a/jmslib/src/main/java/com/redhat/mqe/lib/ClientOptions.java
+++ b/jmslib/src/main/java/com/redhat/mqe/lib/ClientOptions.java
@@ -107,6 +107,7 @@ public abstract class ClientOptions {
     public static final String CON_RETRIES = "conn-reconnect-limit";                     // failover.maxReconnectAttempts (-1)
     public static final String CON_RECONNECT_START_LIMIT = "conn-reconnect-start-limit"; // failover.startupMaxReconnectAttempts
     public static final String CON_RECONNECT_WARN_ATTEMPTS = "conn-reconnect-warn-attempts"; // failover.warnAfterReconnectAttempts
+    public static final String CON_RECONNECT_URL = "conn-reconnect-url";                // additional brokers in broker_list url
 
     // acc Core JMS specific options
     public static final String CON_HA = "conn-ha";                                       // ha
@@ -282,6 +283,7 @@ public abstract class ClientOptions {
             new Option(CON_RECONNECT_WARN_ATTEMPTS, "", "ATTEMPTS", "10", "that often the client will log a message indicating that failover reconnection is being attempted"),
             new Option(CON_HA, "", "ENABLED", "false", "whether connecting broker is in HA topology or not"),
             new Option(CON_RECONNECT_ON_SHUTDOWN, "", "ENABLED", "true", "whether to failover on live broker shutdown in HA"),
+            new Option(CON_RECONNECT_URL, "", "BROKER_URL", "", "additional brokers to add to broker-url as CSV"),
 
             new Option(CON_SSL_KEYSTORE_LOC, "", "LOC", "", "default is to read from the system property \"javax.net.ssl.keyStore\""),
             new Option(CON_SSL_KEYSTORE_PASS, "", "PASS", "", "default is to read from the system property \"javax.net.ssl.keyStorePassword\""),

--- a/jmslib/src/main/java/com/redhat/mqe/lib/ClientOptions.java
+++ b/jmslib/src/main/java/com/redhat/mqe/lib/ClientOptions.java
@@ -107,7 +107,7 @@ public abstract class ClientOptions {
     public static final String CON_RETRIES = "conn-reconnect-limit";                     // failover.maxReconnectAttempts (-1)
     public static final String CON_RECONNECT_START_LIMIT = "conn-reconnect-start-limit"; // failover.startupMaxReconnectAttempts
     public static final String CON_RECONNECT_WARN_ATTEMPTS = "conn-reconnect-warn-attempts"; // failover.warnAfterReconnectAttempts
-    public static final String CON_RECONNECT_URL = "conn-reconnect-url";                // additional brokers in broker_list url
+    public static final String CON_FAILOVER_URLS = "conn-urls";                         // additional brokers in broker_list url
 
     // acc Core JMS specific options
     public static final String CON_HA = "conn-ha";                                       // ha
@@ -283,7 +283,7 @@ public abstract class ClientOptions {
             new Option(CON_RECONNECT_WARN_ATTEMPTS, "", "ATTEMPTS", "10", "that often the client will log a message indicating that failover reconnection is being attempted"),
             new Option(CON_HA, "", "ENABLED", "false", "whether connecting broker is in HA topology or not"),
             new Option(CON_RECONNECT_ON_SHUTDOWN, "", "ENABLED", "true", "whether to failover on live broker shutdown in HA"),
-            new Option(CON_RECONNECT_URL, "", "BROKER_URL", "", "additional brokers to add to broker-url as CSV"),
+            new Option(CON_FAILOVER_URLS, "", "BROKER_URL", "", "additional brokers to add to broker-url as CSV"),
 
             new Option(CON_SSL_KEYSTORE_LOC, "", "LOC", "", "default is to read from the system property \"javax.net.ssl.keyStore\""),
             new Option(CON_SSL_KEYSTORE_PASS, "", "PASS", "", "default is to read from the system property \"javax.net.ssl.keyStorePassword\""),

--- a/jmslib/src/main/java/com/redhat/mqe/lib/CoreClient.java
+++ b/jmslib/src/main/java/com/redhat/mqe/lib/CoreClient.java
@@ -80,6 +80,12 @@ public abstract class CoreClient {
         } else {
             // Use only protocol,credentials,host and port
             brokerUrl = clientOptions.getOption(ClientOptions.BROKER).getValue();
+
+            if (clientOptions.getOption(ClientOptions.CON_RECONNECT_URL).hasParsedValue()) {
+                String reconnectBrokers = clientOptions.getOption(ClientOptions.CON_RECONNECT_URL).getValue();
+                brokerUrl += "," + reconnectBrokers;
+            }
+
             if (clientOptions.getOption(ClientOptions.BROKER_OPTIONS).hasParsedValue()) {
                 brokerUrl += "?" + clientOptions.getOption(ClientOptions.BROKER_OPTIONS).getValue();
             }

--- a/jmslib/src/main/java/com/redhat/mqe/lib/CoreClient.java
+++ b/jmslib/src/main/java/com/redhat/mqe/lib/CoreClient.java
@@ -80,12 +80,6 @@ public abstract class CoreClient {
         } else {
             // Use only protocol,credentials,host and port
             brokerUrl = clientOptions.getOption(ClientOptions.BROKER).getValue();
-
-            if (clientOptions.getOption(ClientOptions.CON_RECONNECT_URL).hasParsedValue()) {
-                String reconnectBrokers = clientOptions.getOption(ClientOptions.CON_RECONNECT_URL).getValue();
-                brokerUrl += "," + reconnectBrokers;
-            }
-
             if (clientOptions.getOption(ClientOptions.BROKER_OPTIONS).hasParsedValue()) {
                 brokerUrl += "?" + clientOptions.getOption(ClientOptions.BROKER_OPTIONS).getValue();
             }
@@ -447,11 +441,15 @@ public abstract class CoreClient {
      */
     static String formBrokerUrl(ClientOptions clientOptions) {
         StringBuilder brkCon = new StringBuilder();
-        brkCon.append(clientOptions.getOption(ClientOptions.PROTOCOL).getValue());
+        if (!clientOptions.getOption(ClientOptions.PROTOCOL).getValue().equals("")) {
+            brkCon.append(clientOptions.getOption(ClientOptions.PROTOCOL).getValue()).append(":");
+        }
+
         if (clientOptions.getOption(ClientOptions.FAILOVER_URL).hasParsedValue()) {
-            brkCon.append(":(").append(clientOptions.getOption(ClientOptions.FAILOVER_URL).getValue()).append(")");
+                brkCon.append("(");
+                brkCon.append(clientOptions.getOption(ClientOptions.FAILOVER_URL).getValue()).append(")");
         } else {
-            brkCon.append("://");
+            brkCon.append("//");
             brkCon.append(clientOptions.getOption(ClientOptions.BROKER_HOST).getValue()).append(":")
                 .append(clientOptions.getOption(ClientOptions.BROKER_PORT).getValue());
         }


### PR DESCRIPTION
Currently clients can't use multiple provided urls as "failover list" for more brokers. 
This is vital for clients, in all cluster scenarios, if client can't get topology (via discovery).

This PR adds --conn-urls parameter to client, to update brokerUrl properly. 
For more details see 
http://file.rdu.redhat.com/~jross/amq-docs/client-core-jms/index.html#reconnect_and_failover
https://activemq.apache.org/failover-transport-reference.html
