### PR TITLE
Revert "FIX(Logging) fixed missing rename for logging"

### DIFF
--- a/cli-activemq/src/main/resources/log4j.properties
+++ b/cli-activemq/src/main/resources/log4j.properties
@@ -24,8 +24,8 @@ log4j.rootLogger=WARN, console
 log4j.logger.com.redhat.mqe.lib=INFO, console
 log4j.additivity.com.redhat.mqe.lib=false
 # Log sent/received messages purely
-log4j.logger.com.redhat.mqe.lib.JmsMessageFormatter=INFO, message
-log4j.additivity.com.redhat.mqe.lib.JmsMessageFormatter=false
+log4j.logger.com.redhat.mqe.lib.MessageFormatter=INFO, message
+log4j.additivity.com.redhat.mqe.lib.MessageFormatter=false
 
 # Log sent/received messages purely
 log4j.logger.com.redhat.mqe.lib.Statistics=INFO, message

--- a/cli-artemis-jms/src/main/resources/log4j.properties
+++ b/cli-artemis-jms/src/main/resources/log4j.properties
@@ -24,8 +24,8 @@ log4j.rootLogger=WARN, console
 log4j.logger.com.redhat.mqe.lib=INFO, console
 log4j.additivity.com.redhat.mqe.lib=false
 # Log sent/received messages purely
-log4j.logger.com.redhat.mqe.lib.JmsMessageFormatter=INFO, message
-log4j.additivity.com.redhat.mqe.lib.JmsMessageFormatter=false
+log4j.logger.com.redhat.mqe.lib.MessageFormatter=INFO, message
+log4j.additivity.com.redhat.mqe.lib.MessageFormatter=false
 
 # Log sent/received messages purely
 log4j.logger.com.redhat.mqe.lib.Statistics=INFO, message

--- a/cli-paho-java/src/main/resources/log4j.properties
+++ b/cli-paho-java/src/main/resources/log4j.properties
@@ -22,8 +22,8 @@ log4j.rootLogger=WARN, console
 log4j.logger.com.redhat.mqe.lib=INFO, console
 log4j.additivity.com.redhat.mqe.lib=false
 # Log sent/received messages purely
-log4j.logger.com.redhat.mqe.lib.JmsMessageFormatter=INFO, message
-log4j.additivity.com.redhat.mqe.lib.JmsMessageFormatter=false
+log4j.logger.com.redhat.mqe.lib.MessageFormatter=INFO, message
+log4j.additivity.com.redhat.mqe.lib.MessageFormatter=false
 # Log sent/received messages purely
 log4j.logger.com.redhat.mqe.lib.Statistics=INFO, message
 log4j.additivity.com.redhat.mqe.lib.Statistics=false

--- a/cli-qpid-jms/src/main/resources/log4j.properties
+++ b/cli-qpid-jms/src/main/resources/log4j.properties
@@ -27,8 +27,8 @@ log4j.rootLogger=ERROR, console
 log4j.logger.com.redhat.mqe.jms=INFO, console
 log4j.additivity.com.redhat.mqe.jms=false
 # Log sent/received messages purely
-log4j.logger.com.redhat.mqe.lib.JmsMessageFormatter=INFO, message
-log4j.additivity.com.redhat.mqe.lib.JmsMessageFormatter=false
+log4j.logger.com.redhat.mqe.lib.MessageFormatter=INFO, message
+log4j.additivity.com.redhat.mqe.lib.MessageFormatter=false
 
 # Log sent/received messages purely
 log4j.logger.com.redhat.mqe.jms.Statistics=INFO, message


### PR DESCRIPTION
This reverts commit 7709082

@michalxo The `JmsMessageFormatter` class is not doing any logging on the info level. `MessageFormatter` is the class that logs/prints messages.

I think your change was completely mistaken and I'd like to revert it.