### PR TITLE
Print physicalName of activemq-client's destination, to avoid duplica…

### DIFF
--- a/cli-activemq/src/main/java/com/redhat/mqe/aoc/AocOpenwireJmsMessageFormatter.java
+++ b/cli-activemq/src/main/java/com/redhat/mqe/aoc/AocOpenwireJmsMessageFormatter.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2018 Red Hat, Inc.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.redhat.mqe.aoc;
+
+import com.redhat.mqe.lib.OpenwireJmsMessageFormatter;
+import org.apache.activemq.command.ActiveMQDestination;
+
+import javax.inject.Inject;
+import javax.jms.Destination;
+import java.security.InvalidParameterException;
+
+public class AocOpenwireJmsMessageFormatter extends OpenwireJmsMessageFormatter {
+    @Inject
+    public AocOpenwireJmsMessageFormatter() {
+    }
+
+    @Override
+    protected String formatAddress(Destination destination) {
+        if (destination == null) {
+            return null;
+        }
+        if (!(destination instanceof ActiveMQDestination)) {
+            throw new InvalidParameterException("Destination must be an ActiveMQ destination, was " + destination.getClass());
+        }
+
+        String address = ((ActiveMQDestination) destination).getPhysicalName();
+        return dropDestinationPrefix(address);
+    }
+}

--- a/cli-activemq/src/main/java/com/redhat/mqe/aoc/Main.java
+++ b/cli-activemq/src/main/java/com/redhat/mqe/aoc/Main.java
@@ -20,7 +20,6 @@
 package com.redhat.mqe.aoc;
 
 import com.redhat.mqe.ClientListener;
-import com.redhat.mqe.lib.Client;
 import com.redhat.mqe.lib.*;
 import dagger.Binds;
 import dagger.BindsInstance;
@@ -38,7 +37,7 @@ final class AocClientModule {
         ConnectionManagerFactory bindConnectionManagerFactory(AocConnectionManagerFactory f);
 
         @Binds
-        JmsMessageFormatter bindMessageFormatter(OpenwireJmsMessageFormatter f);
+        JmsMessageFormatter bindMessageFormatter(AocOpenwireJmsMessageFormatter f);
 
         @Binds
         ClientOptionManager bindClientOptionManager(AocClientOptionManager m);

--- a/cli-activemq/src/test/kotlin/MessageFormatterTest.kt
+++ b/cli-activemq/src/test/kotlin/MessageFormatterTest.kt
@@ -21,6 +21,6 @@ import com.redhat.mqe.lib.AbstractJmsMessageFormatterTest
 import org.apache.activemq.command.ActiveMQBytesMessage
 import javax.jms.BytesMessage
 
-class AocJmsMessageFormatterTest : AbstractJmsMessageFormatterTest() {
+class AocOpenwireJmsMessageFormatterTest : AbstractJmsMessageFormatterTest() {
     override fun getBytesMessage(): BytesMessage = ActiveMQBytesMessage()
 }

--- a/jmslib/src/main/java/com/redhat/mqe/lib/OpenwireJmsMessageFormatter.java
+++ b/jmslib/src/main/java/com/redhat/mqe/lib/OpenwireJmsMessageFormatter.java
@@ -19,7 +19,6 @@
 
 package com.redhat.mqe.lib;
 
-import javax.inject.Inject;
 import javax.jms.JMSException;
 import javax.jms.Message;
 import java.util.HashMap;
@@ -31,10 +30,6 @@ import java.util.Map;
  * Reusable from old client
  */
 public class OpenwireJmsMessageFormatter extends JmsMessageFormatter {
-    @Inject
-    public OpenwireJmsMessageFormatter() {
-    }
-
     /**
      * Openwire -> AMQP mapping http://activemq.apache.org/amqp.html
      */


### PR DESCRIPTION
…te topic://

The toString would append a topic:// or queue:// prefix. Since the message
was sent using the multicastPrefix broker feature, that would result in
duplicated prefix, once from us and once from activemq-client on receiving.

Solution is to use physicalName property of Destination, which does not
add any extra prefixes. The prefix from us is removed by dropDestinationPrefix.