### PR TITLE
Add --will-flag/destination/message/qos/retained options

### DIFF
--- a/cli-paho-java/src/main/java/com/redhat/mqe/amc/Client.java
+++ b/cli-paho-java/src/main/java/com/redhat/mqe/amc/Client.java
@@ -47,6 +47,11 @@ abstract class Client {
     OptionSpec<Integer> msgCount;
     OptionSpec<Void> help;
     OptionSpec<String> logMsgs;
+    OptionSpec<Integer> willFlag;
+    OptionSpec<String> willMessage;
+    OptionSpec<Integer> willQos;
+    OptionSpec<Boolean> willRetained;
+    OptionSpec<String> willDestination;
 
     String cliDestination;
     String cliClientId;
@@ -56,6 +61,11 @@ abstract class Client {
     int cliTimeout;
     int cliMsgCount;
     String cliLogMsgs;
+    int cliWillFlag;
+    String cliWillMessage;
+    int cliWillQos;
+    Boolean cliWillRetained;
+    String cliWillDestination;
 
     AmcMessageFormatter messageFormatter = new AmcMessageFormatter();
 
@@ -99,6 +109,16 @@ abstract class Client {
         logMsgs = parser.accepts("log-msgs", "print messages").withRequiredArg()
             .ofType(String.class).defaultsTo("none");
 
+        willFlag = parser.accepts("will-flag", "will flag (0,1) ").withRequiredArg().ofType(Integer.class).defaultsTo(0);
+
+        willMessage = parser.accepts("will-message", "will message").withRequiredArg().ofType(String.class).defaultsTo("");
+
+        willQos = parser.accepts("will-qos", "will QoS (0,1,2) ").withRequiredArg().ofType(Integer.class).defaultsTo(0);
+
+        willRetained = parser.accepts("will-retained", "is will retained").withRequiredArg().ofType(Boolean.class).defaultsTo(false);
+
+        willDestination = parser.accepts("will-destination", "will topic name").withRequiredArg().ofType(String.class).defaultsTo("");
+
         help = parser.accepts("help", "This help").forHelp();
 
         return parser;
@@ -116,6 +136,11 @@ abstract class Client {
             cliTimeout = optionSet.valueOf(timeout);
             cliMsgCount = optionSet.valueOf(msgCount);
             cliLogMsgs = optionSet.valueOf(logMsgs);
+            cliWillFlag = optionSet.valueOf(willFlag);
+            cliWillMessage = optionSet.valueOf(willMessage);
+            cliWillQos = optionSet.valueOf(willQos);
+            cliWillRetained = optionSet.valueOf(willRetained);
+            cliWillDestination = optionSet.valueOf(willDestination);
         }
     }
 

--- a/cli-paho-java/src/main/java/com/redhat/mqe/amc/Client.java
+++ b/cli-paho-java/src/main/java/com/redhat/mqe/amc/Client.java
@@ -47,7 +47,7 @@ abstract class Client {
     OptionSpec<Integer> msgCount;
     OptionSpec<Void> help;
     OptionSpec<String> logMsgs;
-    OptionSpec<Integer> willFlag;
+    OptionSpec<Boolean> willFlag;
     OptionSpec<String> willMessage;
     OptionSpec<Integer> willQos;
     OptionSpec<Boolean> willRetained;
@@ -61,7 +61,7 @@ abstract class Client {
     int cliTimeout;
     int cliMsgCount;
     String cliLogMsgs;
-    int cliWillFlag;
+    Boolean cliWillFlag;
     String cliWillMessage;
     int cliWillQos;
     Boolean cliWillRetained;
@@ -109,15 +109,15 @@ abstract class Client {
         logMsgs = parser.accepts("log-msgs", "print messages").withRequiredArg()
             .ofType(String.class).defaultsTo("none");
 
-        willFlag = parser.accepts("will-flag", "will flag (0,1) ").withRequiredArg().ofType(Integer.class).defaultsTo(0);
+        willFlag = parser.accepts("conn-will-flag", "will flag (true, false)").withRequiredArg().ofType(Boolean.class).defaultsTo(false);
 
-        willMessage = parser.accepts("will-message", "will message").withRequiredArg().ofType(String.class).defaultsTo("");
+        willMessage = parser.accepts("conn-will-message", "will message body").withRequiredArg().ofType(String.class).defaultsTo("");
 
-        willQos = parser.accepts("will-qos", "will QoS (0,1,2) ").withRequiredArg().ofType(Integer.class).defaultsTo(0);
+        willQos = parser.accepts("conn-will-qos", "will QoS (0,1,2) ").withRequiredArg().ofType(Integer.class).defaultsTo(0);
 
-        willRetained = parser.accepts("will-retained", "is will retained").withRequiredArg().ofType(Boolean.class).defaultsTo(false);
+        willRetained = parser.accepts("conn-will-retained", "is will retained (true, false)").withRequiredArg().ofType(Boolean.class).defaultsTo(false);
 
-        willDestination = parser.accepts("will-destination", "will topic name").withRequiredArg().ofType(String.class).defaultsTo("");
+        willDestination = parser.accepts("conn-will-destination", "will topic name").withRequiredArg().ofType(String.class).defaultsTo("");
 
         help = parser.accepts("help", "This help").forHelp();
 

--- a/cli-paho-java/src/main/java/com/redhat/mqe/amc/Sender.java
+++ b/cli-paho-java/src/main/java/com/redhat/mqe/amc/Sender.java
@@ -71,14 +71,14 @@ public class Sender extends Client {
 
             MqttConnectOptions connectOptions = new MqttConnectOptions();
 
-            if (cliWillFlag == 1) {
+            if (cliWillFlag) {
                 if (cliWillDestination.isEmpty()) {
                     log.severe("Will destination cannot be empty.");
                     System.exit(0);
                 }
 
                 if (cliWillMessage.isEmpty()) {
-                    log.severe("Will message cannot be empty.");
+                    log.severe("Will message body cannot be empty.");
                     System.exit(0);
                 }
 

--- a/cli-paho-java/src/main/java/com/redhat/mqe/amc/Sender.java
+++ b/cli-paho-java/src/main/java/com/redhat/mqe/amc/Sender.java
@@ -68,7 +68,24 @@ public class Sender extends Client {
         try {
             sender = new MqttClient(cliBroker, cliClientId, persistence);
             log.fine("Connecting to broker: " + broker);
-            sender.connect(setConnectionOptions(new MqttConnectOptions()));
+
+            MqttConnectOptions connectOptions = new MqttConnectOptions();
+
+            if (cliWillFlag == 1) {
+                if (cliWillDestination.isEmpty()) {
+                    log.severe("Will destination cannot be empty.");
+                    System.exit(0);
+                }
+
+                if (cliWillMessage.isEmpty()) {
+                    log.severe("Will message cannot be empty.");
+                    System.exit(0);
+                }
+
+                connectOptions.setWill(cliWillDestination, cliWillMessage.getBytes(), cliWillQos, cliWillRetained);
+            }
+
+            sender.connect(setConnectionOptions(connectOptions));
             MqttMessage message = new MqttMessage(cliContent.getBytes());
             message.setQos(cliQos);
             for (int i = 0; i < cliMsgCount; i++) {


### PR DESCRIPTION
Don't know why, but log.severe("message") prints the message 2 times.