### PR TITLE
Add a Mockito based test

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -36,6 +36,7 @@
         <junit.jupiter.version>5.3.0</junit.jupiter.version>
         <junit.platform.version>1.3.0</junit.platform.version>
         <truth.version>0.42</truth.version>
+        <mockito.version>2.22.0</mockito.version>
 
         <plugin.compiler.version>3.8.0</plugin.compiler.version>
         <plugin.assembly.version>3.1.0</plugin.assembly.version>
@@ -141,6 +142,12 @@
                 <groupId>com.google.truth</groupId>
                 <artifactId>truth</artifactId>
                 <version>${truth.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.mockito</groupId>
+                <artifactId>mockito-core</artifactId>
+                <version>${mockito.version}</version>
                 <scope>test</scope>
             </dependency>
 

--- a/jmslib/pom.xml
+++ b/jmslib/pom.xml
@@ -55,5 +55,11 @@
             <artifactId>geronimo-jms_2.0_spec</artifactId>
             <scope>provided</scope>
         </dependency>
+
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/jmslib/src/test/java/com/redhat/mqe/lib/FakeClient.java
+++ b/jmslib/src/test/java/com/redhat/mqe/lib/FakeClient.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2018 Red Hat, Inc.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.redhat.mqe.lib;
+
+import com.redhat.mqe.ClientListener;
+import dagger.Binds;
+import dagger.BindsInstance;
+import dagger.Component;
+import dagger.Module;
+
+import javax.annotation.Nullable;
+import javax.inject.Named;
+
+
+@Component(modules = {FakeClientModule.class})
+interface FakeClient extends Client {
+    ConnectionManagerFactory fakeConnectionManagerFactory();
+
+    @Component.Builder
+    abstract class Builder {
+        @BindsInstance
+        abstract Builder connectionManagerFactory(ConnectionManagerFactory f);
+
+        @BindsInstance
+        abstract Builder messageFormatter(JmsMessageFormatter f);
+
+        @BindsInstance
+        abstract Builder clientOptionManager(ClientOptionManager m);
+
+        @BindsInstance
+        abstract Builder args(@Args String[] args);
+
+        @BindsInstance
+        abstract Builder listener(@Nullable ClientListener listener);
+
+        abstract FakeClient build();
+    }
+}
+
+@Module(includes = FakeClientModule.Declarations.class)
+class FakeClientModule {
+    @Module
+    interface Declarations {
+        @Binds
+        @Named("Sender")
+        ClientOptions bindClientOptions(SenderOptions o);
+
+        @Binds
+        @Named("Receiver")
+        ClientOptions bindReceiverOptions(ReceiverOptions o);
+
+        @Binds
+        @Named("Connector")
+        ClientOptions bindConnectorOptions(ConnectorOptions o);
+    }
+}

--- a/jmslib/src/test/kotlin/com/redhat/mqe/lib/InteractionTest.kt
+++ b/jmslib/src/test/kotlin/com/redhat/mqe/lib/InteractionTest.kt
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2018 Red Hat, Inc.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.redhat.mqe.lib
+
+import com.redhat.mqe.lib.Main.main
+import org.junit.jupiter.api.Test
+import org.mockito.BDDMockito.given
+import org.mockito.Mockito.*
+import javax.jms.*
+
+class InteractionTest {
+    @Test
+    fun `test run sender no params`() {
+        val producer = mock(MessageProducer::class.java)
+
+        val message = mock(Message::class.java)
+
+        val session = mock(Session::class.java)
+        `when`(session.createProducer(any(Destination::class.java)))
+            .thenReturn(producer)
+        `when`(session.createProducer(null))
+            .thenReturn(producer)
+        given(session.createMessage()).willReturn(message)
+
+        val connection = mock(Connection::class.java)
+        `when`(connection.createSession(anyBoolean(), anyInt()))
+            .thenReturn(session)
+
+        val connectionManager = mock(ConnectionManager::class.java)
+        given(connectionManager.getConnection()).willReturn(connection)
+
+        val connectionManagerFactory = mock(ConnectionManagerFactory::class.java)
+        `when`(connectionManagerFactory.make(any(ClientOptions::class.java), anyString()))
+            .thenReturn(connectionManager)
+
+        val args = arrayOf("sender")
+        val client = DaggerFakeClient.builder()
+            .connectionManagerFactory(connectionManagerFactory)
+            .messageFormatter(mock(JmsMessageFormatter::class.java))
+            .clientOptionManager(mock(ClientOptionManager::class.java))
+            .args(args)
+            .build()
+
+        // may need changing, put in mock ClientOptions instead?
+        main(args, client)  // or client.makeSenderClient().startClient()?
+
+        verify(producer).send(message)
+    }
+}

--- a/jmslib/src/test/kotlin/com/redhat/mqe/lib/InteractionTest.kt
+++ b/jmslib/src/test/kotlin/com/redhat/mqe/lib/InteractionTest.kt
@@ -33,22 +33,22 @@ class InteractionTest {
         val message = mock(Message::class.java)
 
         val session = mock(Session::class.java)
-        `when`(session.createProducer(any(Destination::class.java)))
-            .thenReturn(producer)
-        `when`(session.createProducer(null))
-            .thenReturn(producer)
+        given(session.createProducer(any(Destination::class.java)))
+            .willReturn(producer)
+        given(session.createProducer(null))
+            .willReturn(producer)
         given(session.createMessage()).willReturn(message)
 
         val connection = mock(Connection::class.java)
-        `when`(connection.createSession(anyBoolean(), anyInt()))
-            .thenReturn(session)
+        given(connection.createSession(anyBoolean(), anyInt()))
+            .willReturn(session)
 
         val connectionManager = mock(ConnectionManager::class.java)
         given(connectionManager.getConnection()).willReturn(connection)
 
         val connectionManagerFactory = mock(ConnectionManagerFactory::class.java)
-        `when`(connectionManagerFactory.make(any(ClientOptions::class.java), anyString()))
-            .thenReturn(connectionManager)
+        given(connectionManagerFactory.make(any(ClientOptions::class.java), anyString()))
+            .willReturn(connectionManager)
 
         val args = arrayOf("sender")
         val client = DaggerFakeClient.builder()

--- a/jmslib/src/test/kotlin/com/redhat/mqe/lib/InteractionTest.kt
+++ b/jmslib/src/test/kotlin/com/redhat/mqe/lib/InteractionTest.kt
@@ -58,8 +58,7 @@ class InteractionTest {
             .args(args)
             .build()
 
-        // may need changing, put in mock ClientOptions instead?
-        main(args, client)  // or client.makeSenderClient().startClient()?
+        main(args, client)  // or client.makeSenderClient().startClient()
 
         verify(producer).send(message)
     }

--- a/jmslib/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/jmslib/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -132,6 +132,14 @@
             <artifactId>javax.annotation-api</artifactId>
             <version>1.3.2</version>
         </dependency>
+
+        <!--for Mockito, mock-maker-inline-->
+        <dependency>
+            <groupId>com.github.olivergondza</groupId>
+            <artifactId>maven-jdk-tools-wrapper</artifactId>
+            <version>0.1</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <profiles>


### PR DESCRIPTION
Mockito is a mock/spy generation framework. It makes it easier to
replace some objects with test doubles (mocks, spies), then run a program
in a test, and assert about behavior of the code (what methods of the
mocks/spies were called, with what arguments, ...)

This is similar to Byteman, except that the code being tested needs
to be written in a way compatible with mocking. (It must be possible to
pass the mocked objects as constructor/method parameters. Instance
created using `new` cannot be mocked by Mockito.)

Thinking of qe clis as a program that transforms a set of cli options
into JMS API calls, we can use this to check that a given option line
results in the correct api calls. These tests should be faster to run
than end-to-end send/receive using real broker. Embedded or otherwise.