### PR TITLE
fix for Compile tests always, run only !external tests unless -Ptests…

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -33,8 +33,8 @@
         <dagger.version>2.17</dagger.version>
 
         <kotlin.version>1.2.61</kotlin.version>
-        <junit.jupiter.version>5.3.0</junit.jupiter.version>
-        <junit.platform.version>1.3.0</junit.platform.version>
+        <junit.jupiter.version>5.3.1</junit.jupiter.version>
+        <junit.platform.version>1.3.1</junit.platform.version>
         <truth.version>0.42</truth.version>
         <mockito.version>2.22.0</mockito.version>
 

--- a/cli-activemq/src/test/kotlin/MainTest.kt
+++ b/cli-activemq/src/test/kotlin/MainTest.kt
@@ -20,8 +20,10 @@
 import com.redhat.mqe.ClientListener
 import com.redhat.mqe.aoc.Main
 import org.junit.jupiter.api.Disabled
+import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
 
+@Tag("external")
 class AocMainTest : AbstractMainTest() {
 
     override val brokerUrl = "tcp://127.0.0.1:61616"
@@ -82,7 +84,7 @@ class AocMainTest : AbstractMainTest() {
 --property-type String
 """.split(" ", "\n").toTypedArray()
 
-// cannot set Client ID, because more than one connection is created, and these would clash
+    // cannot set Client ID, because more than one connection is created, and these would clash
 //--conn-clientid aClientId
     override val connectorAdditionalOptions = """
 --conn-tcp-traffic-class 2

--- a/cli-artemis-jms/src/test/kotlin/MainTest.kt
+++ b/cli-artemis-jms/src/test/kotlin/MainTest.kt
@@ -21,10 +21,12 @@ import com.google.common.truth.Truth.assertThat
 import com.redhat.mqe.ClientListener
 import com.redhat.mqe.acc.Main
 import org.junit.jupiter.api.Disabled
+import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
 import java.io.File
 import java.nio.file.Files
 
+@Tag("external")
 class AccMainTest : AbstractMainTest() {
 
     override val brokerUrl = "tcp://127.0.0.1:61616"
@@ -93,7 +95,7 @@ class AccMainTest : AbstractMainTest() {
 --property-type String
 """.split(" ", "\n").toTypedArray()
 
-// cannot set Client ID, because more than one connection is created, and these would clash
+    // cannot set Client ID, because more than one connection is created, and these would clash
 //--conn-clientid aClientId
     override val connectorAdditionalOptions = """
 --conn-async-acks true

--- a/cli-paho-java/src/test/kotlin/MainTest.kt
+++ b/cli-paho-java/src/test/kotlin/MainTest.kt
@@ -21,8 +21,10 @@ import com.redhat.mqe.ClientListener
 import com.redhat.mqe.amc.Main
 import org.junit.jupiter.api.Assumptions
 import org.junit.jupiter.api.Disabled
+import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
 
+@Tag("external")
 class AmcMainTest : AbstractMainTest() {
 
     override val brokerUrl = "tcp://127.0.0.1:1883"
@@ -31,7 +33,7 @@ class AmcMainTest : AbstractMainTest() {
     override val senderAdditionalOptions = """
 """.split(" ", "\n").toTypedArray()
 
-// cannot set Client ID, because more than one connection is created, and these would clash
+    // cannot set Client ID, because more than one connection is created, and these would clash
 //--conn-clientid aClientId
     override val connectorAdditionalOptions = """
 """.split(" ", "\n").toTypedArray()

--- a/cli-qpid-jms/src/test/kotlin/MainTest.kt
+++ b/cli-qpid-jms/src/test/kotlin/MainTest.kt
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.function.Executable
 import java.time.Duration
 
+@Tag("external")
 class AacMainTest : AbstractMainTest() {
 
     override val brokerUrl = "amqp://127.0.0.1:5672"
@@ -88,7 +89,7 @@ class AacMainTest : AbstractMainTest() {
 """.split(" ", "\n").toTypedArray()
 
 
-// cannot set Client ID, because more than one connection is created, and these would clash
+    // cannot set Client ID, because more than one connection is created, and these would clash
 //--conn-clientid aClientId
     override val connectorAdditionalOptions = """
 --conn-async-send true

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -191,9 +191,9 @@
                 </configuration>
                 <dependencies>
                     <dependency>
-                        <groupId>org.junit.jupiter</groupId>
-                        <artifactId>junit-jupiter-engine</artifactId>
-                        <version>${junit.jupiter.version}</version>
+                        <groupId>org.junit.platform</groupId>
+                        <artifactId>junit-platform-surefire-provider</artifactId>
+                        <version>${junit.platform.version}</version>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/tests/src/test/kotlin/AbstractMainTest.kt
+++ b/tests/src/test/kotlin/AbstractMainTest.kt
@@ -77,6 +77,7 @@ fun assertNoSystemExit(executable: () -> Unit) {
     }
 }
 
+@Tag("external")
 abstract class AbstractMainTest {
     abstract val brokerUrl: String
     abstract val sslBrokerUrl: String


### PR DESCRIPTION
… is specified

First time, this commit did not work, reported and applied a workaround
https://issues.apache.org/jira/browse/SUREFIRE-1577.

Also, tags on methods maybe are not inherited? So sprinkled the tag
more widely for good measure.

Original commit message:

Tests were only compiled if -Ptests was specified. This caused weird
errors when switching from `mvn` command to intellij ide and back.

Also, it decreased utility of having the tests.

With this change, tests that are cheap to run (do not require external
broker running on the same machine) are being run.