### PR TITLE
Don't hash null objects, just leave them as they are

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,16 @@
 sudo: false
 language: java
+# oraclejdk8 is not available on releases after trusty
+# https://travis-ci.community/t/install-of-oracle-jdk-8-failing/3038/8
+dist: trusty
 jdk:
-  - openjdk8
-  - oraclejdk8
-  - openjdk11
-  - oraclejdk11
+    - openjdk8
+    - oraclejdk8
+    - openjdk11
+    - oraclejdk11
 
 services:
-  - docker
+    - docker
 
 env:
   global:

--- a/jmslib/src/main/java/com/redhat/mqe/lib/JmsMessageFormatter.java
+++ b/jmslib/src/main/java/com/redhat/mqe/lib/JmsMessageFormatter.java
@@ -22,11 +22,25 @@ package com.redhat.mqe.lib;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.jms.*;
+import javax.jms.BytesMessage;
+import javax.jms.DeliveryMode;
+import javax.jms.Destination;
+import javax.jms.JMSException;
+import javax.jms.MapMessage;
+import javax.jms.Message;
+import javax.jms.MessageEOFException;
+import javax.jms.MessageFormatException;
+import javax.jms.ObjectMessage;
+import javax.jms.StreamMessage;
+import javax.jms.TextMessage;
 import java.math.BigInteger;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 /**
  * JmsMessageFormatter abstraction layer for all protocols.
@@ -109,7 +123,10 @@ public abstract class JmsMessageFormatter extends MessageFormatter {
         result.put("type", msg.getJMSType()); // not everywhere, amqp does not have it
     }
 
-    private Object hash(Object o) {
+    private String hash(Object o) {
+        if (o == null) {
+            return null; // no point in hashing this value
+        }
         MessageDigest md;
         try {
             md = MessageDigest.getInstance("SHA-1");


### PR DESCRIPTION
Previously, we would in such cases crash with

[12:56:48] [INFO] dtestlib.Test :: stderr:
  Exception in thread "main" java.lang.NullPointerException
  	at com.redhat.mqe.lib.JmsMessageFormatter.hash(JmsMessageFormatter.java:119)
  	at com.redhat.mqe.lib.JmsMessageFormatter.addFormatJMS11(JmsMessageFormatter.java:108)
  	at com.redhat.mqe.lib.AMQPJmsMessageFormatter.formatMessage(AMQPJmsMessageFormatter.java:35)
  	at com.redhat.mqe.lib.JmsMessageFormatter.formatMessageAsDict(JmsMessageFormatter.java:133)
  	at com.redhat.mqe.lib.CoreClient.printMessage(CoreClient.java:381)
  	at com.redhat.mqe.lib.ReceiverClient.consumeMessage(ReceiverClient.java:241)
  	at com.redhat.mqe.lib.ReceiverClient.startClient(ReceiverClient.java:149)
  	at com.redhat.mqe.lib.Main.main(Main.java:46)
  	at com.redhat.mqe.jms.Main.main(Main.java:80)
  	at com.redhat.mqe.jms.Main.main(Main.java:84)