### PR TITLE
Added --on-release option for cli-qpid-jms sender

### DIFF
--- a/cli-qpid-jms/src/main/java/com/redhat/mqe/jms/AacSenderOptions.java
+++ b/cli-qpid-jms/src/main/java/com/redhat/mqe/jms/AacSenderOptions.java
@@ -74,7 +74,8 @@ public class AacSenderOptions extends AacClientOptions {
             new Option(TX_ENDLOOP_ACTION, "", "TXACTION", "None", "transactional action after sending all messages in loop (commit|rollback|recover|None)"),
             // TODO
             new Option(SYNC_MODE, "", "SYNCMODE", "action", "synchronization mode: none/session/action/persistent/transient"),
-            new Option(CAPACITY, "", "CAPACITY", "-1", "sender|receiver capacity (no effect in jms atm)")
+            new Option(CAPACITY, "", "CAPACITY", "-1", "sender|receiver capacity (no effect in jms atm)"),
+            new Option(ON_RELEASE, "", "ACTION", "fail", "fail|ignore|retry action to perform if message is released by receiver")
         ));
     }
 

--- a/jmslib/src/main/java/com/redhat/mqe/lib/ClientOptions.java
+++ b/jmslib/src/main/java/com/redhat/mqe/lib/ClientOptions.java
@@ -217,6 +217,8 @@ public abstract class ClientOptions {
     public static final String MSG_GROUP_SEQ = "msg-group-seq";
     public static final String MSG_REPLY_TO_GROUP_ID = "msg-reply-to-group-id";
 
+    public static final String ON_RELEASE = "on-release";
+
     /**
      * CONNECTOR
      */


### PR DESCRIPTION
This change allows users to specify --on-release action in case receiver releases a message.
Currently it causes the sender to fail. It might happen frequently when using QPID Dispatch
in scenarios when multiple receivers are disconnecting in parallel.