### PR TITLE
Pm ignore remote connection close

### DIFF
--- a/cli-qpid-jms/src/main/java/com/redhat/mqe/jms/AacClientOptions.java
+++ b/cli-qpid-jms/src/main/java/com/redhat/mqe/jms/AacClientOptions.java
@@ -83,6 +83,7 @@ public abstract class AacClientOptions extends ClientOptions {
     static final String CON_CLIENTID_PREFIX = "conn-clientid-prefix";             // jms.clientIDPrefix
     static final String CON_CONNID_PREFIX = "conn-connid-prefix";                 // jms.connectionIDPrefix
     static final String CON_POPULATE_JMSXUSERID = "conn-populate-user-id";        // jms.populateJMSXUserID
+    static final String CON_IGNORE_REMOTE_CLOSE = "conn-ignore-remote-close";     // ignore remote connection close
 
     static final String CON_PREFETCH_QUEUE = "conn-prefetch-queue";               // jms.prefetchPolicy.queuePrefetch
     static final String CON_PREFETCH_TOPIC = "conn-prefetch-topic";               // jms.prefetchPolicy.topicPrefetch
@@ -238,6 +239,7 @@ public abstract class AacClientOptions extends ClientOptions {
             new Option(CON_ASYNC_ACKS, "", "ENABLED", "false", "causes all Message acknowledgments to be sent asynchronously"),
             new Option(CON_LOC_MSG_PRIO, "", "ENABLED", "false", "prefetched messages are reordered locally based on their given priority"),
             new Option(CON_VALID_PROP_NAMES, "", "ENABLED", "true", "message property names should be validated as valid Java identifiers"),
+            new Option(CON_IGNORE_REMOTE_CLOSE, "", "ENABLED", "false", "ignore remote connection close"),
 
             new Option(CON_RECV_LOCAL_ONLY, "", "ENABLED", "false", "if enabled receive calls with a timeout will only check a consumers local message buffer"),
             new Option(CON_RECV_NOWAIT_LOCAL, "", "ENABLED", "false", "if enabled receiveNoWait calls will only check a consumers local message buffer"),

--- a/jmslib/src/main/java/com/redhat/mqe/lib/ClientOptionManager.java
+++ b/jmslib/src/main/java/com/redhat/mqe/lib/ClientOptionManager.java
@@ -426,6 +426,10 @@ public abstract class ClientOptionManager {
                 // will use jndi connection factory, nothing to do here
                 return;
             }
+            if (option.getName().equals(ClientOptions.CON_IGNORE_REMOTE_CLOSE)) {
+                // ignore remote connection close, nothing to do here
+                return;
+            }
             LOG.error("Connection option {} is not recognized! ", option.getName());
             System.exit(2);
         }

--- a/jmslib/src/main/java/com/redhat/mqe/lib/ClientOptions.java
+++ b/jmslib/src/main/java/com/redhat/mqe/lib/ClientOptions.java
@@ -85,6 +85,7 @@ public abstract class ClientOptions {
     public static final String CON_CONN_TIMEOUT = "conn-conn-timeout";                   // jms.connectTimeout
     public static final String CON_CLIENTID_PREFIX = "conn-clientid-prefix";             // jms.clientIDPrefix
     public static final String CON_CONNID_PREFIX = "conn-connid-prefix";                 // jms.connectionIDPrefix
+    public static final String CON_IGNORE_REMOTE_CLOSE = "conn-ignore-remote-close";     // ignore remote connection close
 
     public static final String CON_PREFETCH_QUEUE = "conn-prefetch-queue";               // jms.prefetchPolicy.queuePrefetch
     public static final String CON_PREFETCH_TOPIC = "conn-prefetch-topic";               // jms.prefetchPolicy.topicPrefetch
@@ -273,6 +274,7 @@ public abstract class ClientOptions {
             new Option(CON_CONN_TIMEOUT, "", "TIMEOUT", "15", "timeout value that controls how long the client waits on Connection establishment before returning with an error"),
             new Option(CON_CLIENTID_PREFIX, "", "PREFIX", "ID:", "client ID prefix for new connections"),
             new Option(CON_CONNID_PREFIX, "", "PREFIX", "ID:", "connection ID prefix used for a new connections. Usable for tracking connections in logs"),
+            new Option(CON_IGNORE_REMOTE_CLOSE, "", "ENABLED", "false", "ignore remote connection close"),
 
             new Option(CON_MAX_REDELIVERIES, "", "COUNT", "-1", "maximum number of allowed message redeliveries"),
             new Option(CON_PREFETCH_QUEUE, "", "COUNT", "1000", "number of messages which can be held in a prefetch buffer"),

--- a/jmslib/src/main/java/com/redhat/mqe/lib/CoreClient.java
+++ b/jmslib/src/main/java/com/redhat/mqe/lib/CoreClient.java
@@ -338,7 +338,8 @@ public abstract class CoreClient {
             session.close();
         } catch (JMSException e) {
             e.printStackTrace();
-            if (e.getClass().getName().toString().equals("org.apache.qpid.jms.JmsConnectionRemotelyClosedException")) {
+            if (getClientOptions().getOption(ClientOptions.CON_IGNORE_REMOTE_CLOSE).getValue().equals("true")
+                && e.getClass().getName().toString().equals("org.apache.qpid.jms.JmsConnectionRemotelyClosedException")) {
                 return;  // suppress error, explained at https://issues.redhat.com/browse/MSGQE-8155
             }
             System.exit(1);

--- a/jmslib/src/main/java/com/redhat/mqe/lib/CoreClient.java
+++ b/jmslib/src/main/java/com/redhat/mqe/lib/CoreClient.java
@@ -338,6 +338,9 @@ public abstract class CoreClient {
             session.close();
         } catch (JMSException e) {
             e.printStackTrace();
+            if (e.getClass().getName().toString().equals("org.apache.qpid.jms.JmsConnectionRemotelyClosedException")) {
+                return;  // suppress error, explained at https://issues.redhat.com/browse/MSGQE-8155
+            }
             System.exit(1);
         }
     }


### PR DESCRIPTION
wrt the current cli-* listener clients implementation, the connection close from remote peer might be expected.

This brings additional jmslib dependency on org.apache.qpid.jms, I hope that's fine. However, I'm not sure how to deal with the version of qpid-jms-client added to the pom file, do we need to update it periodically or is there a better solution?

btw. we might have an option to identify whether we want to ignore the exception, but I don't think it's really necessary.