### PR TITLE
Upgrade to qpid-jms 2.0.0

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -87,7 +87,13 @@
                 <version>${annotations.version}</version>
             </dependency>
 
-            <!--JMS dependencies-->
+            <!--modern JMS dependencies-->
+            <dependency>
+                <groupId>jakarta.jms</groupId>
+                <artifactId>jakarta.jms-api</artifactId>
+                <version>3.0.0</version>
+            </dependency>
+            <!--legacy JMS dependencies-->
             <dependency>
                 <groupId>org.apache.geronimo.specs</groupId>
                 <artifactId>geronimo-jms_1.1_spec</artifactId>
@@ -112,12 +118,31 @@
             </dependency>
             <dependency>
                 <groupId>com.redhat.cli-java</groupId>
+                <artifactId>jakartalib</artifactId>
+                <version>1.2.2-SNAPSHOT</version>
+            </dependency>
+            <dependency>
+                <groupId>com.redhat.cli-java</groupId>
                 <artifactId>lib</artifactId>
                 <version>1.2.2-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>com.redhat.cli-java</groupId>
                 <artifactId>tests</artifactId>
+                <version>1.2.2-SNAPSHOT</version>
+                <type>test-jar</type>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>com.redhat.cli-java</groupId>
+                <artifactId>jmslib</artifactId>
+                <version>1.2.2-SNAPSHOT</version>
+                <type>test-jar</type>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>com.redhat.cli-java</groupId>
+                <artifactId>jakartalib</artifactId>
                 <version>1.2.2-SNAPSHOT</version>
                 <type>test-jar</type>
                 <scope>test</scope>

--- a/cli-activemq/pom.xml
+++ b/cli-activemq/pom.xml
@@ -61,6 +61,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>com.redhat.cli-java</groupId>
+            <artifactId>jmslib</artifactId>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>com.google.truth</groupId>
             <artifactId>truth</artifactId>
             <scope>test</scope>

--- a/cli-qpid-jms/pom.xml
+++ b/cli-qpid-jms/pom.xml
@@ -35,7 +35,7 @@
     <properties>
         <bundle.symbolic.name.suffix>jms</bundle.symbolic.name.suffix>
         <jar.main.class>com.redhat.mqe.jms.Main</jar.main.class>
-        <qpid.jms.client.version>1.6.0</qpid.jms.client.version>
+        <qpid.jms.client.version>2.0.0</qpid.jms.client.version>
         <library.version>${qpid.jms.client.version}</library.version>
         <tcnative.version>2.0.52.Final</tcnative.version>
         <tcnative.classifier>linux-x86_64-fedora</tcnative.classifier>
@@ -68,7 +68,7 @@
 
         <dependency>
             <groupId>com.redhat.cli-java</groupId>
-            <artifactId>jmslib</artifactId>
+            <artifactId>jakartalib</artifactId>
         </dependency>
 
         <dependency>
@@ -96,6 +96,12 @@
         <dependency>
             <groupId>com.redhat.cli-java</groupId>
             <artifactId>tests</artifactId>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.redhat.cli-java</groupId>
+            <artifactId>jakartalib</artifactId>
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>

--- a/cli-qpid-jms/src/main/java/com/redhat/mqe/jms/AacConnectionManager.java
+++ b/cli-qpid-jms/src/main/java/com/redhat/mqe/jms/AacConnectionManager.java
@@ -28,10 +28,10 @@ import org.apache.qpid.jms.JmsTopic;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.jms.Connection;
-import javax.jms.JMSException;
-import javax.jms.Queue;
-import javax.jms.Topic;
+import jakarta.jms.Connection;
+import jakarta.jms.JMSException;
+import jakarta.jms.Queue;
+import jakarta.jms.Topic;
 
 public class AacConnectionManager extends ConnectionManager {
     static final String QUEUE_OBJECT = "javax.jms.Queue";

--- a/cli-qpid-jms/src/test/java/ConnectWithoutPassword.java
+++ b/cli-qpid-jms/src/test/java/ConnectWithoutPassword.java
@@ -25,9 +25,9 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import util.Broker;
 
-import javax.jms.Connection;
-import javax.jms.ConnectionFactory;
-import javax.jms.JMSSecurityException;
+import jakarta.jms.Connection;
+import jakarta.jms.ConnectionFactory;
+import jakarta.jms.JMSSecurityException;
 import java.time.Duration;
 
 @SuppressWarnings("Duplicates")

--- a/cli-qpid-jms/src/test/java/ENTMQCL1860.java
+++ b/cli-qpid-jms/src/test/java/ENTMQCL1860.java
@@ -27,11 +27,11 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import util.Broker;
 import util.BrokerFixture;
 
-import javax.jms.Connection;
-import javax.jms.Message;
-import javax.jms.MessageConsumer;
-import javax.jms.MessageProducer;
-import javax.jms.Session;
+import jakarta.jms.Connection;
+import jakarta.jms.Message;
+import jakarta.jms.MessageConsumer;
+import jakarta.jms.MessageProducer;
+import jakarta.jms.Session;
 import java.util.concurrent.TimeUnit;
 
 import static com.google.common.truth.Truth.assertThat;
@@ -63,7 +63,7 @@ class ENTMQCL1860 {
 
         try {
             Session session = connection.createSession(false, Session.AUTO_ACKNOWLEDGE);
-            javax.jms.Queue queue = session.createQueue(getQueueName());
+            jakarta.jms.Queue queue = session.createQueue(getQueueName());
             MessageProducer producer = session.createProducer(queue);
             producer.send(session.createMessage());
             connection.close();

--- a/cli-qpid-jms/src/test/java/QPIDJMS412Test.java
+++ b/cli-qpid-jms/src/test/java/QPIDJMS412Test.java
@@ -12,11 +12,11 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import util.Broker;
 
-import javax.jms.Connection;
-import javax.jms.ConnectionFactory;
-import javax.jms.JMSException;
-import javax.jms.JMSSecurityException;
-import javax.jms.Session;
+import jakarta.jms.Connection;
+import jakarta.jms.ConnectionFactory;
+import jakarta.jms.JMSException;
+import jakarta.jms.JMSSecurityException;
+import jakarta.jms.Session;
 
 import static com.google.common.truth.Truth.assertThat;
 

--- a/cli-qpid-jms/src/test/java/QPIDJMS451Test.java
+++ b/cli-qpid-jms/src/test/java/QPIDJMS451Test.java
@@ -28,14 +28,14 @@ import org.junit.jupiter.api.io.TempDir;
 import util.Broker;
 import util.BrokerFixture;
 
-import javax.jms.Session;
-import javax.jms.TextMessage;
-import javax.jms.Topic;
-import javax.jms.TopicConnection;
-import javax.jms.TopicConnectionFactory;
-import javax.jms.TopicPublisher;
-import javax.jms.TopicSession;
-import javax.jms.TopicSubscriber;
+import jakarta.jms.Session;
+import jakarta.jms.TextMessage;
+import jakarta.jms.Topic;
+import jakarta.jms.TopicConnection;
+import jakarta.jms.TopicConnectionFactory;
+import jakarta.jms.TopicPublisher;
+import jakarta.jms.TopicSession;
+import jakarta.jms.TopicSubscriber;
 import java.nio.file.Path;
 
 class QPIDJMS451Test {

--- a/cli-qpid-jms/src/test/java/QPIDJMS484Test.java
+++ b/cli-qpid-jms/src/test/java/QPIDJMS484Test.java
@@ -35,11 +35,11 @@ import org.junit.jupiter.api.io.TempDir;
 import util.Broker;
 import util.BrokerFixture;
 
-import javax.jms.Connection;
-import javax.jms.Destination;
-import javax.jms.Message;
-import javax.jms.MessageConsumer;
-import javax.jms.Session;
+import jakarta.jms.Connection;
+import jakarta.jms.Destination;
+import jakarta.jms.Message;
+import jakarta.jms.MessageConsumer;
+import jakarta.jms.Session;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Iterator;

--- a/cli-qpid-jms/src/test/kotlin/MessageFormatterTest.kt
+++ b/cli-qpid-jms/src/test/kotlin/MessageFormatterTest.kt
@@ -20,7 +20,7 @@
 import com.redhat.mqe.lib.AbstractJmsMessageFormatterTest
 import org.apache.qpid.jms.message.JmsBytesMessage
 import org.apache.qpid.jms.provider.amqp.message.AmqpJmsBytesMessageFacade
-import javax.jms.BytesMessage
+import jakarta.jms.BytesMessage
 
 class AacJmsMessageFormatterTest : AbstractJmsMessageFormatterTest() {
     override fun getBytesMessage(): BytesMessage = JmsBytesMessage(AmqpJmsBytesMessageFacade())

--- a/cli-qpid-jms/src/test/kotlin/QPIDJMS357Test.kt
+++ b/cli-qpid-jms/src/test/kotlin/QPIDJMS357Test.kt
@@ -24,9 +24,9 @@ import org.junit.jupiter.api.Tags
 import org.junit.jupiter.api.Test
 import java.math.BigInteger
 import java.util.*
-import javax.jms.Connection
-import javax.jms.ConnectionFactory
-import javax.jms.Session
+import jakarta.jms.Connection
+import jakarta.jms.ConnectionFactory
+import jakarta.jms.Session
 
 @Tags(Tag("issue"), Tag("external"))
 class QPIDJMS357Test {

--- a/cli-qpid-jms/src/test/kotlin/QPIDJMS391Test.kt
+++ b/cli-qpid-jms/src/test/kotlin/QPIDJMS391Test.kt
@@ -32,9 +32,9 @@ import java.io.File
 import java.math.BigInteger
 import java.nio.file.Path
 import java.util.*
-import javax.jms.Connection
-import javax.jms.ConnectionFactory
-import javax.jms.Session
+import jakarta.jms.Connection
+import jakarta.jms.ConnectionFactory
+import jakarta.jms.Session
 
 @Tag("issue")
 class QPIDJMS391Test {

--- a/cli-qpid-jms/src/test/kotlin/QPIDJMS502Test.kt
+++ b/cli-qpid-jms/src/test/kotlin/QPIDJMS502Test.kt
@@ -32,9 +32,9 @@ import util.Broker
 import java.math.BigInteger
 import java.nio.file.Path
 import java.util.*
-import javax.jms.Connection
-import javax.jms.ConnectionFactory
-import javax.jms.Session
+import jakarta.jms.Connection
+import jakarta.jms.ConnectionFactory
+import jakarta.jms.Session
 
 @Tag("issue")
 class QPIDJMS502Test {

--- a/jakartalib/pom.xml
+++ b/jakartalib/pom.xml
@@ -68,4 +68,22 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <!-- https://stackoverflow.com/questions/174560/sharing-test-code-in-maven#174670 -->
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>${plugin.jar.version}</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>test-jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
 </project>

--- a/jakartalib/pom.xml
+++ b/jakartalib/pom.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2022 Red Hat, Inc.
+  ~
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements. See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License. You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.redhat.cli-java</groupId>
+        <artifactId>parent</artifactId>
+        <version>1.2.2-SNAPSHOT</version>
+        <relativePath>../parent/pom.xml</relativePath>
+    </parent>
+
+    <artifactId>jakartalib</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>${jackson.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.checkerframework</groupId>
+            <artifactId>checker-qual</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.redhat.cli-java</groupId>
+            <artifactId>lib</artifactId>
+            <version>1.2.2-SNAPSHOT</version>
+        </dependency>
+
+        <!--scope provided means that it is a compileOnly dependency-->
+        <dependency>
+            <groupId>jakarta.jms</groupId>
+            <artifactId>jakarta.jms-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.google.truth</groupId>
+            <artifactId>truth</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/jakartalib/src/main/java/com/redhat/mqe/lib/AMQPJmsMessageFormatter.java
+++ b/jakartalib/src/main/java/com/redhat/mqe/lib/AMQPJmsMessageFormatter.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2017 Red Hat, Inc.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.redhat.mqe.lib;
+
+import jakarta.jms.JMSException;
+import jakarta.jms.Message;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Message output formatter to python dict,
+ * map, or any other object printable format.
+ * Reusable from old client
+ */
+public class AMQPJmsMessageFormatter extends JmsMessageFormatter {
+    public Map<String, Object> formatMessage(Message msg, boolean hashContent) throws JMSException {
+        Map<String, Object> result = new HashMap<>();
+        addFormatJMS11(msg, result, hashContent);
+        addFormatJMS20(msg, result);
+        return result;
+    }
+}

--- a/jakartalib/src/main/java/com/redhat/mqe/lib/Args.java
+++ b/jakartalib/src/main/java/com/redhat/mqe/lib/Args.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2017 Red Hat, Inc.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.redhat.mqe.lib;
+
+/**
+ * Annotation to mark the String[] args argument for DI
+ */
+public @interface Args {
+}

--- a/jakartalib/src/main/java/com/redhat/mqe/lib/Client.java
+++ b/jakartalib/src/main/java/com/redhat/mqe/lib/Client.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2017 Red Hat, Inc.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.redhat.mqe.lib;
+
+/**
+ * Parent interface for Dagger components
+ */
+public interface Client {
+    SenderClient makeSenderClient();
+
+    ReceiverClient makeReceiverClient();
+
+    ConnectorClient makeConnectorClient();
+}

--- a/jakartalib/src/main/java/com/redhat/mqe/lib/ClientOptionManager.java
+++ b/jakartalib/src/main/java/com/redhat/mqe/lib/ClientOptionManager.java
@@ -1,0 +1,491 @@
+/*
+ * Copyright (c) 2017 Red Hat, Inc.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.redhat.mqe.lib;
+
+import joptsimple.ArgumentAcceptingOptionSpec;
+import joptsimple.OptionException;
+import joptsimple.OptionParser;
+import joptsimple.OptionSet;
+import joptsimple.OptionSpec;
+import joptsimple.OptionSpecBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+
+/**
+ * Class provides support for parsing supplied options
+ * from command line for given client.
+ * Each supplied option is checked against template/default
+ * client options list, then accordingly set for client.
+ */
+public abstract class ClientOptionManager {
+    private static final Logger LOG = LoggerFactory.getLogger(ClientOptionManager.class);
+    /**
+     * Mapping from cli options to connection factory properties.
+     * Null value means key should not become connection factory property.
+     */
+    protected final Map<String, String> CONNECTION_TRANSLATION_MAP = new HashMap<>();
+    protected Map<String, String> connectionOptionsUrlMap = new HashMap<>();
+    private List<Option> updatedOptions = new ArrayList<>();
+    public static final String QUEUE_PREFIX = "queue://";
+    public static final String TOPIC_PREFIX = "topic://";
+
+    private static final String protocol = "(?<protocol>\\w+(?:\\+?\\w+)*://)?";
+    private static final String credentials = "(?:(?<username>\\w*)?:?(?<password>\\w*)?@)?";
+    private static final String hostname = "(?<hostname>\\[[a-fA-F0-9:]+\\]|[a-zA-Z0-9-_.]+):(?<port>[0-9]+)";
+    private static final String query = "(?:\\?(?<query>.*)?)?";
+
+    /**
+     * Parses command line arguments and applies them to supplied ClientOptions.
+     * <p>
+     * ClientOption values are modified when particular client requires it.
+     * For example, conversion from seconds to milliseconds.
+     * <p>
+     * ClientOptions that are derived from other options are also computed and set by this method.
+     * Most importantly, this means BROKER_URI.
+     *
+     * @param clientOptions to be updated
+     * @param args          user command line arguments to be parsed
+     */
+    public void applyClientArguments(ClientOptions clientOptions, String[] args) {
+        OptionParser parser = createParser(clientOptions.getClientOptions());
+        parseInputOptions(clientOptions, parser, args);
+    }
+
+    /**
+     * Create jOpt parser from supplied client options.
+     *
+     * @param options allowed by client
+     * @return jOpt parser
+     */
+    public static OptionParser createParser(List<Option> options) {
+        OptionParser parser = new OptionParser();
+        for (Option opt : options) {
+            if (opt.isCliArgument()) {
+                if (opt.getLongOptionName().equals(ClientOptions.HELP)) {
+                    parser.acceptsAll(Arrays.asList(opt.getShortOptionName(),
+                        opt.getLongOptionName()), opt.getDescription());
+                    continue;
+                }
+
+                // username and password options can have no argument
+                if (opt.getLongOptionName().equals(ClientOptions.USERNAME)
+                    || opt.getLongOptionName().equals(ClientOptions.PASSWORD)) {
+                    parser.accepts(opt.getLongOptionName()).withOptionalArg().ofType(String.class).describedAs(opt.getDescription());
+                    continue;
+                }
+
+                OptionSpecBuilder optionSpecBuilder;
+                if (!opt.getShortOptionName().equals("") && !opt.getLongOptionName().equals("")) {
+                    optionSpecBuilder = parser.acceptsAll(Arrays.asList(opt.getShortOptionName(),
+                        opt.getLongOptionName()), opt.getDescription());
+                } else if (opt.getLongOptionName().equals("")) {
+                    optionSpecBuilder = parser.accepts(opt.getShortOptionName(), opt.getDescription());
+                } else {
+                    optionSpecBuilder = parser.accepts(opt.getLongOptionName(), opt.getDescription());
+                }
+
+                if (opt.hasArgument()) {
+                    ArgumentAcceptingOptionSpec<String> optionSpec = optionSpecBuilder.withRequiredArg().describedAs(opt.getArgumentExample());
+                    // TODO possibly all options with arguments should have default values(?)
+                    if (!opt.getDefaultValue().equals("")) {
+                        optionSpec.defaultsTo(opt.getDefaultValue());
+                    }
+                }
+            }
+        }
+        return parser;
+    }
+
+    /**
+     * Parse the options. Print help if "help" was supplied.
+     *
+     * @param clientOptions supplied client options
+     * @param parser        jOpt parser to be used for parsing command line arguemnts
+     * @param argv          user command line input
+     */
+    private void parseInputOptions(ClientOptions clientOptions, OptionParser parser, String[] argv) {
+        try {
+            OptionSet options = parser.parse(argv);
+
+            if (options.has(ClientOptions.HELP)) {
+                printHelp(parser);
+                System.exit(0);
+            } else {
+                // Iterate over options & set client option/s accordingly
+                for (Map.Entry<OptionSpec<?>, List<?>> entry : options.asMap().entrySet()) {
+                    OptionSpec<?> spec = entry.getKey();
+                    if (options.has(spec)) {
+                        LOG.trace(spec + " : " + entry.getValue() + " :: " + options.has(spec));
+                        // Set parsed option for the client option
+                        try {
+                            setClientOptions(clientOptions.getOption(getOptionName(spec.options())), options, clientOptions);
+                        } catch (MessagingException me) {
+                            LOG.error(me.toString(), me.getMessage());
+                            me.printStackTrace();
+                            System.exit(2);
+                        }
+                    }
+                }
+
+                // SetClientOptions() case: ClientOptions.BROKER
+                setBrokerUrlFromOptions(clientOptions, options);
+
+                clientOptions.setUpdatedOptions(updatedOptions);
+                createConnectionOptions(clientOptions);
+                if (clientOptions.getUpdatedOptionsMap().keySet().contains(ClientOptions.BROKER)
+                    || !clientOptions.getUpdatedOptionsMap().keySet().contains(ClientOptions.BROKER_URI)) {
+                    checkAndSetOption(ClientOptions.BROKER,
+                        clientOptions.getOption(ClientOptions.BROKER).getValue() + getConnectionOptionsAsUrl(),
+                        clientOptions);
+                }
+                // Check if use transactions (set it all accordingly, if yes)
+                if (options.has(ClientOptions.TX_SIZE) || options.has(ClientOptions.TX_ACTION) || options.has(ClientOptions.TX_ENDLOOP_ACTION)) {
+                    checkAndSetOption(clientOptions.getOption(ClientOptions.TRANSACTED).getName(), "true", clientOptions);
+
+                }
+            }
+        } catch (OptionException x) {
+            System.err.println("Unknown parameter has been detected: " + x.getMessage());
+            printHelp(parser);
+            System.exit(2);
+        }
+    }
+
+    private void setBrokerUrlFromOptions(ClientOptions clientOptions, OptionSet options) {
+        Option brokerOption = clientOptions.getOption(ClientOptions.BROKER);
+        setBrokerOptions(clientOptions, (String) options.valueOf(ClientOptions.BROKER));
+        brokerOption.setParsedValue(CoreClient.formBrokerUrl(clientOptions));
+    }
+
+    protected void createConnectionOptions(ClientOptions clientOptions) {
+//    for (Option clientOption : clientOptions.getClientOptions()) {
+        for (Option clientOption : clientOptions.getUpdatedOptions()) {
+            // OptionName starts with "conn-"
+            if (clientOption.getName().startsWith(ClientOptions.CON_HEARTBEAT.substring(0, 4))) {
+                addConnectionOptions(clientOption);
+            }
+        }
+    }
+
+    /**
+     * Workaround for unmodifiable list, to always get the longOption (= option name).
+     *
+     * @param options list of current options
+     * @return longOption Option name
+     */
+    private static String getOptionName(List<String> options) {
+        List<String> tmp = new ArrayList<>(options);
+        if (options.size() > 1) {
+            Collections.sort(tmp, new StringLengthComparator());
+        }
+        return tmp.get(0);
+    }
+
+    /**
+     * Set client option based on command line arguments.
+     * Option.parsedValue is set accordingly.
+     *
+     * @param clientOption Option of the client
+     * @param options      parsed option from command line
+     * @throws MessagingException
+     */
+    private void setClientOptions(Option clientOption, OptionSet options, ClientOptions clientOptions) throws MessagingException {
+        // Check for multiple argument input values
+        if (options.valuesOf(clientOption.getName()).size() == 1
+            && !ClientOptions.argsAcceptingMultipleValues.contains(clientOption.getName())) {
+            LOG.trace("Single value: " + options.valueOf(clientOption.getName()));
+            String optionName = clientOption.getName();
+
+            switch (optionName) {
+                case ClientOptions.BROKER:
+                    // Broker value is set once all options are parsed and set via setBrokerUrlFromOptions
+                    break;
+                case ClientOptions.ADDRESS:
+                    String address = (String) options.valueOf(ClientOptions.ADDRESS);
+                    if (address.startsWith(TOPIC_PREFIX)) {
+                        checkAndSetOption(ClientOptions.DESTINATION_TYPE, ConnectionManager.TOPIC_OBJECT, clientOptions);
+                    }
+                    if (address.startsWith(TOPIC_PREFIX) || address.startsWith(QUEUE_PREFIX)) {
+                        address = address.substring(TOPIC_PREFIX.length()); // len(TOPIC_PREFIX==QUEUE_PREFIX)
+                    }
+                    checkAndSetOption(ClientOptions.ADDRESS, address, clientOptions);
+                    LOG.trace("Address=" + clientOption.getValue());
+                    break;
+                default:
+                    clientOption.setParsedValue(options.valueOf(clientOption.getName()));
+                    break;
+            }
+        } else if (options.valuesOf(clientOption.getName()).size() == 0) {
+            if (clientOption.getName().equals(ClientOptions.USERNAME)
+                || clientOption.getName().equals(ClientOptions.PASSWORD)) {
+                clientOption.setParsedValue(clientOption.getDefaultValue());
+            } else {
+                // no argument option (switch)
+                clientOption.setParsedValue("true");
+                LOG.trace("Enabled no argument option: " + clientOption.getName());
+            }
+        } else {
+            // has multiple values, set only allowed types with multiple values
+            LOG.trace("Multiple values: " + options.valuesOf(clientOption.getName()));
+            if (ClientOptions.argsAcceptingMultipleValues.contains(clientOption.getName())) {
+                clientOption.setParsedValue(options.valuesOf(clientOption.getName()));
+            } else {
+                // if (option not in allowedMultiArgsList):
+                throw new MessagingException("Option " + clientOption.getName()
+                    + " has wrong argument(s): " + options.valueOf(clientOption.getName()));
+            }
+        }
+        updatedOptions.add(clientOption);
+    }
+
+    /**
+     * Gather data for protocol,username,password, primary host,port and options
+     * provided from 'broker' or 'broker-url' argument.
+     *
+     * @param clientOptions
+     * @param brokerUrl
+     */
+    protected void setBrokerOptions(ClientOptions clientOptions, String brokerUrl) {
+        // TODO new discovery failover has been added
+        // TODO failover.nested options for clients has been changed, broker in list can have custom options
+        Map<String, String> patternOptionMapping = new HashMap<>();
+        patternOptionMapping.put("protocol", ClientOptions.PROTOCOL);
+        patternOptionMapping.put("username", ClientOptions.USERNAME);
+        patternOptionMapping.put("password", ClientOptions.PASSWORD);
+        patternOptionMapping.put("hostname", ClientOptions.BROKER_HOST);
+        patternOptionMapping.put("port", ClientOptions.BROKER_PORT);
+        patternOptionMapping.put("query", ClientOptions.BROKER_OPTIONS);
+
+        // Search for the first protocol, hostname and port in provided url. Also get username and password if they are provided
+        Pattern pattern = Pattern.compile(protocol + credentials + hostname + query);
+        Matcher matcher = pattern.matcher(brokerUrl);
+        if (matcher.find()) {
+            for (String groupName : patternOptionMapping.keySet()) {
+                try {
+                    if (matcher.group(groupName) != null) {
+                        checkAndSetOption(patternOptionMapping.get(groupName), matcher.group(groupName), clientOptions);
+                    }
+                } catch (IllegalArgumentException e) {
+                    LOG.trace("Group {} not found", groupName);
+                }
+            }
+        } else {
+            LOG.error("Wrongly parsed BrokerURI:\"" + brokerUrl + "\"");
+            System.exit(2);
+        }
+    }
+
+    /**
+     * Append an AMQP protocol to broker url for all possible connecting options (simple, failover, discovery)
+     *
+     * @param brokerUrl provided broker url by user
+     * @return updated broker url with expected amqp protocol
+     */
+    protected String appendMissingProtocol(String brokerUrl) {
+        StringBuilder newBrokerUrl = new StringBuilder();
+
+        String[] brokerUrls = brokerUrl.split(",");
+        Pattern pattern = Pattern.compile(protocol + hostname + query);
+
+        String tmpUrl;
+        for (String simpleBrokerUrl : brokerUrls) {
+            Matcher matcher = pattern.matcher(simpleBrokerUrl);
+            if (matcher.find()) {
+                if (matcher.group("protocol") == null) {
+                    String prefix = getUrlProtocol();
+                    tmpUrl = prefix + "://" + matcher.group();
+                } else {
+                    tmpUrl = matcher.group();
+                }
+                newBrokerUrl.append(tmpUrl).append(",");
+            } else {
+                LOG.error("Unable to parse broker-url '" + brokerUrl + "'.");
+                System.exit(2);
+            }
+        }
+        newBrokerUrl.deleteCharAt(newBrokerUrl.length() - 1);
+        LOG.trace("FinalBrokerUrl=" + newBrokerUrl.toString());
+        return newBrokerUrl.toString();
+    }
+
+    protected abstract String getUrlProtocol();
+
+    /**
+     * Method sets broker options like hostname, port, credentials, protocol.
+     * Also sets various simple options like transaction, & other..
+     *
+     * @param optionName    to be set to ClientOptions (broker_port, broker_host, password, transaction ..)
+     * @param value         value of the option
+     * @param clientOptions ClientOptions to be used/modified
+     */
+
+    protected static void checkAndSetOption(String optionName, String value, ClientOptions clientOptions) {
+        LOG.trace(optionName + "->" + value);
+        if (value != null) {
+            if (value.endsWith("://")) {
+                value = value.replace("://", "");
+            }
+            clientOptions.getOption(optionName).setParsedValue(value);
+        }
+    }
+
+    /**
+     * Merge two maps together. Client specific values are not overridden by default common options.
+     *
+     * @param commonOpts - default options for clients
+     * @param clientOpts - customized options for given client
+     * @return client options map, filled with default common options
+     */
+    public static List<Option> mergeOptionLists(List<Option> commonOpts, List<Option> clientOpts) {
+        LOG.trace("OPTS common:" + commonOpts.size() + "+ cli:" + clientOpts.size());
+        for (Option commonOption : commonOpts) {
+            if (!clientOpts.contains(commonOption)) {
+                // add default key-value into clientOpts
+                clientOpts.add(commonOption);
+            } else {
+                LOG.warn("Option " + commonOption + " is already present in the client map. Skip?");
+            }
+        }
+        return clientOpts;
+    }
+
+    static void printHelp(OptionParser parser) {
+        try {
+            // TODO customize help output
+            parser.printHelpOn(System.out);
+        } catch (IOException e) {
+            e.printStackTrace();
+            System.exit(1);
+        }
+    }
+
+    /**
+     * Fill connectionOptionsUrlMap with the data.
+     * If needed convert the client input connection option
+     * to the appropriate jms connection option.
+     * Also, if needed, change seconds to milliseconds.
+     */
+    void addConnectionOptions(Option option) {
+        if (CONNECTION_TRANSLATION_MAP.containsKey(option.getName())) {
+            String jmsConOptionNames = CONNECTION_TRANSLATION_MAP.get(option.getName());
+            if (jmsConOptionNames != null) {
+                for (String jmsConOptionName : jmsConOptionNames.split(";")) {
+                    if (jmsConOptionName.equals("")) {
+                        System.out.println("ignored option: " + option.getName());
+                        continue;
+                    }
+                    if (option.getName().equals(ClientOptions.CON_HEARTBEAT)) {
+                        Integer value = Math.round(Float.parseFloat(option.getValue()) * 1000);
+                        connectionOptionsUrlMap.put(jmsConOptionName, value.toString());
+                    } else {
+                        connectionOptionsUrlMap.put(jmsConOptionName, option.getValue());
+                    }
+                }
+            }
+        } else {
+            if (option.getName().equals(ClientOptions.CON_RECONNECT)) {
+                // use failover mechanism, conn-reconnect does not perform nor add any other action to the client
+                return;
+            }
+            if (option.getName().equals(ClientOptions.CON_FAILOVER_URLS)) {
+                // add CSV of broker urls failover mechanism, conn-reconnect
+                return;
+            }
+            if (option.getName().equals(ClientOptions.CONN_USE_CONFIG_FILE)) {
+                // will use jndi connection factory, nothing to do here
+                return;
+            }
+            if (option.getName().equals(ClientOptions.CON_IGNORE_REMOTE_CLOSE)) {
+                // ignore remote connection close, nothing to do here
+                return;
+            }
+            LOG.error("Connection option {} is not recognized! ", option.getName());
+            System.exit(2);
+        }
+    }
+
+//  /**
+//   * Create connection url from given options.
+//   *
+//   * @return string of options starting as "?<conOpts..>"
+//   */
+//  static String getConnectionOptionsAsUrl() {
+//    if (connectionOptionsUrlMap != null) {
+//      UriBuilder urlBuilder = UriBuilder.fromPath("");
+//      for (String optionName : connectionOptionsUrlMap.keySet()) {
+//        urlBuilder.queryParam(optionName, connectionOptionsUrlMap.get(optionName));
+//      }
+//      return urlBuilder.build().toASCIIString();
+//    } else {
+//      return "";
+//    }
+//  }
+
+    /**
+     * Create connection url from given options.
+     *
+     * @return string of options starting as "?<conOpts..>"
+     */
+    private String getConnectionOptionsAsUrl() {
+        StringBuilder conOptUrl = new StringBuilder();
+        for (String optionName : connectionOptionsUrlMap.keySet()) {
+            String divider = (conOptUrl.length() == 0) ? "?" : "&";
+            try {
+                conOptUrl
+                    .append(divider)
+                    .append(URLEncoder.encode(optionName, "UTF-8"))
+                    .append("=")
+                    .append(URLEncoder.encode(connectionOptionsUrlMap.get(optionName), "UTF-8"));
+            } catch (UnsupportedEncodingException e) {
+                throw new IllegalArgumentException("Encoding 'UTF-8' is not supported", e);
+            }
+        }
+        return conOptUrl.toString();
+    }
+}
+
+class StringLengthComparator implements Comparator<String> {
+    /**
+     * Sort by descending order (from the longest to the shortest).
+     *
+     * @param s1 first String
+     * @param s2 second String
+     * @return -1 if s1 is longer, 0 when equally long string, 1 if s2 is longer
+     */
+    @Override
+    public int compare(String s1, String s2) {
+        if (s1.length() == s2.length()) return 0;
+        return (s1.length() > s2.length()) ? -1 : 1;
+    }
+}

--- a/jakartalib/src/main/java/com/redhat/mqe/lib/ClientOptions.java
+++ b/jakartalib/src/main/java/com/redhat/mqe/lib/ClientOptions.java
@@ -1,0 +1,419 @@
+/*
+ * Copyright (c) 2017 Red Hat, Inc.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.redhat.mqe.lib;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.inject.Inject;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Interface provides support for manipulating
+ * with default options for clients.
+ */
+public abstract class ClientOptions {
+
+    @Inject
+        // TODO(jdanek): this initialization is confusing, admittedly
+    void setOptions(ClientOptionManager clientOptionManager, @Args String[] args) {
+        clientOptionManager.applyClientArguments(this, args);
+    }
+
+    protected static final Logger LOG = LoggerFactory.getLogger(ReceiverOptions.class);
+    protected static final String OUT = "out";
+    private static final Map<String, String> translationDtestJmsMap = new HashMap<String, String>();
+    public static final String CON_SSL_ENA = "conn-ssl-ena";
+    private final List<Option> defaultOptions = new ArrayList<>();
+    private List<Option> updatedOptions = new ArrayList<>();
+    static List<String> argsAcceptingMultipleValues = new ArrayList<>();
+    static List<String> failoverProtocols = new ArrayList<>();
+    static List<Option> numericArgumentValueOptionList = new ArrayList<>();
+
+    /* Mapping of client option to jms client is done in CoreClient.CONNECTION_TRANSLATION_MAP */
+    public static final String BROKER = "broker";
+    public static final String BROKER_URI = "broker-uri";
+    static final String TRANSACTED = "transacted";
+    public static final String MSG_DURABLE = "msg-durable";
+    public static final String ADDRESS = "address";
+    public static final String DURATION = "duration";
+    public static final String DURATION_MODE = "duration-mode";
+    static final String LOG_LEVEL = "log-lib";
+    static final String LOG_STATS = "log-stats";
+    public static final String LOG_BYTES = "log-bytes";
+    public static final String USERNAME = "conn-username";                               // jms.username
+    public static final String PASSWORD = "conn-password";                               // jms.password
+    static final String HELP = "help";
+    static final String SSN_ACK_MODE = "ssn-ack-mode";
+    public static final String CLOSE_SLEEP = "close-sleep";
+
+    public static final String CON_HEARTBEAT = "conn-heartbeat";                         // amqp.idleTimeout=[ms] * 1000ms
+    public static final String CON_VHOST = "conn-vhost";                                 // amqp.vhost
+    public static final String CON_SASL_MECHS = "conn-auth-mechanisms";                  // amqp.saslMechanisms
+    public static final String CON_SASL_LAYER = "conn-auth-sasl";                        // amqp.saslLayer
+
+    public static final String CON_CLIENTID = "conn-clientid";                           // jms.clientID
+    public static final String CON_ASYNC_SEND = "conn-async-send";                       // jms.forceAsyncSend
+    public static final String CON_SYNC_SEND = "conn-sync-send";                         // jms.alwaysSyncSend
+    public static final String CON_ASYNC_ACKS = "conn-async-acks";                       // jms.sendAcksAsync
+    public static final String CON_LOC_MSG_PRIO = "conn-local-msg-priority";             // jms.localMessagePriority
+    public static final String CON_VALID_PROP_NAMES = "conn-valid-prop-names";           // jms.validatePropertyNames
+    public static final String CON_QUEUE_PREFIX = "conn-queue-prefix";                   // jms.queuePrefix
+    public static final String CON_TOPIC_PREFIX = "conn-topic-prefix";                   // jms.topicPrefix
+    public static final String CON_CLOSE_TIMEOUT = "conn-close-timeout";                 // jms.closeTimeout
+    public static final String CON_CONN_TIMEOUT = "conn-conn-timeout";                   // jms.connectTimeout
+    public static final String CON_CLIENTID_PREFIX = "conn-clientid-prefix";             // jms.clientIDPrefix
+    public static final String CON_CONNID_PREFIX = "conn-connid-prefix";                 // jms.connectionIDPrefix
+    public static final String CON_IGNORE_REMOTE_CLOSE = "conn-ignore-remote-close";     // ignore remote connection close
+
+    public static final String CON_PREFETCH_QUEUE = "conn-prefetch-queue";               // jms.prefetchPolicy.queuePrefetch
+    public static final String CON_PREFETCH_TOPIC = "conn-prefetch-topic";               // jms.prefetchPolicy.topicPrefetch
+    public static final String CON_PREFETCH_BROWSER = "conn-prefetch-browser";           // jms.prefetchPolicy.queueBrowserPrefetch
+    public static final String CON_PREFETCH_DUR_TOPIC = "conn-prefetch-topic-dur";       // jms.prefetchPolicy.durableTopicPrefetch
+    public static final String CON_PREFETCH_ALL = "conn-prefetch";                       // jms.prefetchPolicy.all
+
+    public static final String CON_MAX_REDELIVERIES = "conn-redeliveries-max";           // jms.redeliveryPolicy.maxRedeliveries
+
+    public static final String CON_TCP_SEND_BUF_SIZE = "conn-tcp-buf-size-send";         // transport.sendBufferSize
+    public static final String CON_TCP_RECV_BUF_SIZE = "conn-tcp-buf-size-recv";         // transport.receiveBufferSize
+    public static final String CON_TCP_TRAFFIC_CLASS = "conn-tcp-traffic-class";         // transport.trafficClass
+    public static final String CON_TCP_CON_TIMEOUT = "conn-tcp-conn-timeout";            // transport.connectTimeout
+    public static final String CON_TCP_SOCK_TIMEOUT = "conn-tcp-sock-timeout";           // transport.soTimeout
+    public static final String CON_TCP_SOCK_LINGER = "conn-tcp-sock-linger";             // transport.soLinger
+    public static final String CON_TCP_KEEP_ALIVE = "conn-tcp-keep-alive";               // transport.tcpKeepAlive
+
+    public static final String CON_RECONNECT = "conn-reconnect";                         // enable reconnect options
+    public static final String CON_RECONNECT_INITIAL_DELAY = "conn-reconnect-initial-delay"; // failover.initialReconnectDelay (0)
+    public static final String CON_RECONNECT_TIMEOUT = "conn-reconnect-timeout";         // failover.reconnectDelay (10ms)
+    public static final String CON_RECONNECT_INTERVAL = "conn-reconnect-interval";       // failover.maxReconnectDelay (30sec)
+    public static final String CON_RECONNECT_BACKOFF = "conn-reconnect-backoff";         // failover.useReconnectBackOff (true)
+    public static final String CON_RECONNECT_BACKOFF_MULTIPLIER = "conn-reconnect-backoff-multiplier"; // failover.reconnectBackOffMultiplier
+    public static final String CON_RETRIES = "conn-reconnect-limit";                     // failover.maxReconnectAttempts (-1)
+    public static final String CON_RECONNECT_START_LIMIT = "conn-reconnect-start-limit"; // failover.startupMaxReconnectAttempts
+    public static final String CON_RECONNECT_WARN_ATTEMPTS = "conn-reconnect-warn-attempts"; // failover.warnAfterReconnectAttempts
+    public static final String CON_FAILOVER_URLS = "conn-urls";                         // additional brokers in broker_list url
+
+    // acc Core JMS specific options
+    public static final String CON_HA = "conn-ha";                                       // ha
+    public static final String CON_RECONNECT_ON_SHUTDOWN = "conn-reconnect-on-shutdown"; // failoverOnServerShutdown
+
+
+    public static final String CON_SSL_KEYSTORE_LOC = "conn-ssl-keystore-location";      // transport.keyStoreLocation
+    public static final String CON_SSL_KEYSTORE_PASS = "conn-ssl-keystore-password";     // transport.keyStorePassword
+    public static final String CON_SSL_TRUSTSTORE_LOC = "conn-ssl-truststore-location";  // transport.trustStoreLocation
+    public static final String CON_SSL_TRUSTSTORE_PASS = "conn-ssl-truststore-password"; // transport.trustStorePassword
+    public static final String CON_SSL_STORE_TYPE = "conn-ssl-store-type";               // transport.storeType
+    public static final String CON_SSL_CONTEXT_PROTOCOL = "conn-ssl-context-proto";      // transport.contextProtocol
+    public static final String CON_SSL_ENA_CIPHERED = "conn-ssl-ena-ciphered-suites";    // transport.enabledCipherSuites
+    public static final String CON_SSL_DIS_CIPHERED = "conn-ssl-dis-ciphered-suites";    // transport.disabledCipherSuites
+    public static final String CON_SSL_ENA_PROTOS = "conn-ssl-ena-protos";               // transport.enabledProtocols
+    public static final String CON_SSL_DIS_PROTOS = "conn-ssl-dis-protos";               // transport.disabledProtocols
+    public static final String CON_SSL_TRUST_ALL = "conn-ssl-trust-all";                 // transport.trustAll
+    public static final String CON_SSL_VERIFY_HOST = "conn-ssl-verify-host";             // transport.verifyHost
+    public static final String CON_SSL_KEYALIAS = "conn-ssl-key-alias";                  // transport.keyAlias
+
+
+    // OpenWire
+    public static final String CONN_CACHE_ENA = "conn-cache-ena";                        // wireFormat.cacheEnabled
+    public static final String CONN_CACHE_SIZE = "conn-cache-size";                      // wireFormat.cacheSize
+    public static final String CONN_MAX_INACTITVITY_DUR = "conn-max-inactivity-dur";     // wireFormat.maxInactivityDuration
+    public static final String CONN_MAX_INACTITVITY_DUR_INIT_DELAY = "conn-max-inactivity-dur-init-delay";  // wireFormat.maxInactivityDurationInitalDelay
+    public static final String CONN_MAX_FRAME_SIZE = "conn-max-frame-size";               // wireFormat.maxFrameSize
+    public static final String CONN_PREFIX_PACKET_SIZE_ENA = "conn-prefix-packet-size-ena";    // wireFormat.prefixPacketSize
+    public static final String CONN_SERVER_STACK_TRACE_ENA = "conn-server-stack-trace-ena";    // wireFormat.stackTraceEnabled
+    public static final String CONN_TCP_NO_DELAY = "conn-tcp-no-delay";                   // wireFormat.tcpNoDelayEnabled
+    public static final String CONN_TIGHT_ENCODING_ENA = "conn-tight-encoding-ena";      // wireFormat.tightEncodingEnabled
+    public static final String CONN_WATCH_TOPIC_ADVISORIES = "conn-watch-topic-advisories";
+
+    // TODO Not implemented by client libraries
+//  static final String CON_SSL_PROTOCOL = "conn-ssl-protocol";
+
+    // These few options are not settable from outside. Client sets them up when setting parsed options.
+    public static final String PROTOCOL = "protocol";
+    static final String BROKER_HOST = "broker_host";
+    static final String BROKER_PORT = "broker_port";
+    public static final String BROKER_OPTIONS = "broker_options";
+    public static final String DESTINATION_TYPE = "destination_type";
+    public static final String FAILOVER_PROTO = "failover";
+    static final String DISCOVERY_PROTO = "discovery";
+    public static final String FAILOVER_URL = "failover_url";
+
+    /**
+     * S+R+?
+     */
+    static final String TIMEOUT = "timeout";
+    public static final String COUNT = "count";
+    static final String LOG_MSGS = "log-msgs";
+    public static final String TX_SIZE = "tx-size";
+    public static final String TX_ACTION = "tx-action";
+    public static final String TX_ENDLOOP_ACTION = "tx-endloop-action";
+    static final String CAPACITY = "capacity";
+    public static final String TRACE_MESSAGES = "trace-messages";
+
+    public static final String MSG_CONTENT_HASHED = "msg-content-hashed";
+    public static final String MSG_CONTENT_STREAM = "msg-content-stream";
+
+    public static final String CONN_USE_CONFIG_FILE = "conn-use-config-file";
+
+    /**
+     * RECEIVER Options
+     */
+    static final String ACTION = "action";
+    static final String SYNC_MODE = "sync-mode";
+    static final String MSG_LISTENER = "msg-listener-ena";
+    static final String DURABLE_SUBSCRIBER = "durable-subscriber";
+    static final String UNSUBSCRIBE = "subscriber-unsubscribe";
+    static final String DURABLE_SUBSCRIBER_PREFIX = "durable-subscriber-prefix";
+    static final String DURABLE_SUBSCRIBER_NAME = "durable-subscriber-name";
+    static final String MSG_SELECTOR = "msg-selector";
+    public static final String BROWSER = "recv-browse";
+    static final String PROCESS_REPLY_TO = "process-reply-to";
+    static final String MSG_BINARY_CONTENT_TO_FILE = "msg-binary-content-to-file";
+    public static final String MSG_CONTENT_TO_FILE = "msg-content-to-file";
+
+    /**
+     * SENDER
+     */
+    public static final String MSG_TTL = "msg-ttl";
+    public static final String MSG_PRIORITY = "msg-priority";
+    public static final String MSG_ID = "msg-id";
+    public static final String MSG_REPLY_TO = "msg-reply-to";
+    public static final String MSG_SUBJECT = "msg-subject";
+    public static final String MSG_USER_ID = "msg-user-id";
+    public static final String MSG_CORRELATION_ID = "msg-correlation-id";
+    static final String MSG_NOTIMESTAMP = "msg-no-timestamp";
+
+    public static final String PROPERTY_TYPE = "property-type";
+    public static final String MSG_PROPERTY = "msg-property";
+    public static final String CONTENT_TYPE = "content-type";
+    public static final String MSG_CONTENT = "msg-content";
+    public static final String MSG_CONTENT_BINARY = "msg-content-binary";
+    public static final String MSG_CONTENT_TYPE = "msg-content-type";
+    public static final String MSG_CONTENT_FROM_FILE = "msg-content-from-file";
+    public static final String MSG_CONTENT_MAP_ITEM = "msg-content-map-item";
+    public static final String MSG_CONTENT_LIST_ITEM = "msg-content-list-item";
+
+    public static final String MSG_GROUP_ID = "msg-group-id";
+    public static final String MSG_GROUP_SEQ = "msg-group-seq";
+    public static final String MSG_REPLY_TO_GROUP_ID = "msg-reply-to-group-id";
+
+    public static final String ON_RELEASE = "on-release";
+
+    /**
+     * CONNECTOR
+     */
+    static final String OBJ_CTRL = "obj-ctrl";
+    static final String Q_COUNT = "q-count";
+
+    /**
+     * QMF Options?
+     * TODO qmf options
+     */
+
+    static {
+        translationDtestJmsMap.put("", "");
+        argsAcceptingMultipleValues.addAll(Arrays.asList(MSG_CONTENT_LIST_ITEM, MSG_CONTENT_MAP_ITEM, MSG_PROPERTY));
+        failoverProtocols.addAll(Arrays.asList(FAILOVER_PROTO, DISCOVERY_PROTO));
+    }
+
+    public ClientOptions() {
+        defaultOptions.addAll(Arrays.asList(// Options updated by parsing broker/broker-url
+            new Option(PROTOCOL, "tcp"),
+            new Option(BROKER_HOST, "localhost"),
+            new Option(BROKER_PORT, "61616"),
+            new Option(BROKER_OPTIONS, ""),
+            new Option(DESTINATION_TYPE, ConnectionManager.QUEUE_OBJECT),
+
+            new Option(USERNAME, "", "USERNAME", "", "jms.username (not defined before host:port in qpid-jms-client)"),
+            new Option(PASSWORD, "", "PASSWORD", "", "jms.password (not defined before host:port in qpid-jms-client)"),
+            new Option(HELP, "h", "", "", "show this help"),
+            new Option(BROKER, "b", "HOST:61616", "tcp://localhost:61616", "url broker to connect to, default"),
+            new Option(BROKER_URI, "", "OpenwireJmsURL", "tcp://localhost:61616[[?conOpt=val]&conOpt=val]",
+                "AMQP JMS QPID specific broker uri. NOTE: This options overrides everything related to broker & connection options. " +
+                    "It is used as exactly as provided!"),
+            new Option(LOG_LEVEL, "", "LEVEL", "info", "logging level of the client. trace/debug/info/warn/error"),
+            new Option(LOG_STATS, "", "LEVEL", "INFO", "report various statistic/debug information"), // ?
+            new Option(SSN_ACK_MODE, "", "ACKMODE", "auto", "session acknowledge mode auto/client/dups_ok/(individual)"),
+            new Option(CLOSE_SLEEP, "", "CSLEEP", "0", "sleep before publisher/subscriber/session/connection.close() in floating seconds"),
+
+            new Option(CON_HEARTBEAT, "", "SECONDS", "", "mapped to " + CONN_MAX_INACTITVITY_DUR + " option"),
+            new Option(CON_VHOST, "", "VHOST", "", "virtual hostname to connect to. (Default: main from URI)"),
+            new Option(CON_SASL_LAYER, "", "ENABLED", "true", "choose whether SASL layer should be used"),
+            new Option(CON_SASL_MECHS, "", "MECHS", "all", "comma separated list of SASL mechanisms allowed by client for authentication (plain/anonymous/external/cram-md5?/digest-md5?)"),
+
+            new Option(CON_CLIENTID, "", "CLIENTID", "", "clientID value that is applied to the connection."),
+            new Option(CON_ASYNC_SEND, "", "ENABLED", "false", "send all messages asynchronously (if false only non-persistent and transacted are send asynchronously"),
+            new Option(CON_SYNC_SEND, "", "ENABLED", "false", "send all messages synchronously"),
+            new Option(CON_ASYNC_ACKS, "", "ENABLED", "false", "causes all Message acknowledgments to be sent asynchronously"),
+            new Option(CON_LOC_MSG_PRIO, "", "ENABLED", "false", "prefetched messages are reordered locally based on their given priority"),
+            new Option(CON_VALID_PROP_NAMES, "", "ENABLED", "true", "message property names should be validated as valid Java identifiers"),
+            new Option(CON_QUEUE_PREFIX, "", "PREFIX", "", "optional prefix value added to the name of any Queue created from a JMS Session"),
+            new Option(CON_TOPIC_PREFIX, "", "PREFIX", "", "optional prefix value added to the name of any Topic created from a JMS Session."),
+            new Option(CON_CLOSE_TIMEOUT, "", "TIMEOUT", "15", "timeout value that controls how long the client waits on Connection close before returning"),
+            new Option(CON_CONN_TIMEOUT, "", "TIMEOUT", "15", "timeout value that controls how long the client waits on Connection establishment before returning with an error"),
+            new Option(CON_CLIENTID_PREFIX, "", "PREFIX", "ID:", "client ID prefix for new connections"),
+            new Option(CON_CONNID_PREFIX, "", "PREFIX", "ID:", "connection ID prefix used for a new connections. Usable for tracking connections in logs"),
+            new Option(CON_IGNORE_REMOTE_CLOSE, "", "ENABLED", "false", "ignore remote connection close"),
+
+            new Option(CON_MAX_REDELIVERIES, "", "COUNT", "-1", "maximum number of allowed message redeliveries"),
+            new Option(CON_PREFETCH_QUEUE, "", "COUNT", "1000", "number of messages which can be held in a prefetch buffer"),
+            new Option(CON_PREFETCH_TOPIC, "", "COUNT", "1000", "number of messages which can be held in a prefetch buffer"),
+            new Option(CON_PREFETCH_BROWSER, "", "COUNT", "1000", "number of messages which can be held in a prefetch buffer"),
+            new Option(CON_PREFETCH_DUR_TOPIC, "", "COUNT", "1000", "number of messages which can be held in a prefetch buffer"),
+            new Option(CON_PREFETCH_ALL, "", "COUNT", "1000", "set prefetch values to all prefetch options"),
+
+            new Option(CON_RECONNECT, "", "ENABLED", "false", "enable default failover reconnect"),
+            new Option(CON_RETRIES, "", "COUNT", "-1", "retry to connect to the broker that many times"),
+            new Option(CON_RECONNECT_TIMEOUT, "", "MS", "10", "delay between successive reconnection attempts; constant if backoff is off"),
+            new Option(CON_RECONNECT_INTERVAL, "", "SEC", "30", "maximum time that client will wait before next reconnect. Used only when backoff is on"),
+            new Option(CON_RECONNECT_BACKOFF, "", "ENABLED", "true", "choose to use backoff multiplier or not"),
+            new Option(CON_RECONNECT_BACKOFF_MULTIPLIER, "", "VALUE", "2.0", "backoff multiplier for reconnect intervals"),
+            new Option(CON_RECONNECT_START_LIMIT, "", "INTERVAL", "-1", "For a client that has never connected to a remote peer before, this sets " +
+                "the number of attempts made to connect before reporting the connection as failed. The default is value of maxReconnectAttempts"),
+            new Option(CON_RECONNECT_INITIAL_DELAY, "", "DELAY", "0", "delay the client will wait before the first attempt to reconnect to a remote peer"),
+            new Option(CON_RECONNECT_WARN_ATTEMPTS, "", "ATTEMPTS", "10", "that often the client will log a message indicating that failover reconnection is being attempted"),
+            new Option(CON_HA, "", "ENABLED", "false", "whether connecting broker is in HA topology or not"),
+            new Option(CON_RECONNECT_ON_SHUTDOWN, "", "ENABLED", "true", "whether to failover on live broker shutdown in HA"),
+            new Option(CON_FAILOVER_URLS, "", "BROKER_URL", "", "additional brokers to add to broker-url as CSV"),
+
+            new Option(CON_SSL_KEYSTORE_LOC, "", "LOC", "", "default is to read from the system property \"javax.net.ssl.keyStore\""),
+            new Option(CON_SSL_KEYSTORE_PASS, "", "PASS", "", "default is to read from the system property \"javax.net.ssl.keyStorePassword\""),
+            new Option(CON_SSL_TRUSTSTORE_LOC, "", "LOC", "", "default is to read from the system property \"javax.net.ssl.trustStore\""),
+            new Option(CON_SSL_TRUSTSTORE_PASS, "", "PASS", "", "default is to read from the system property \"javax.net.ssl.keyStorePassword\""),
+            new Option(CON_SSL_STORE_TYPE, "", "TYPE", "JKS", "store type"),
+            new Option(CON_SSL_CONTEXT_PROTOCOL, "", "PROTOCOL", "TLS", "protocol argument used when getting an SSLContext"),
+            new Option(CON_SSL_ENA_CIPHERED, "", "SUITES", "", "enabled cipher suites (comma separated list); disabled ciphers are removed from this list."),
+            new Option(CON_SSL_DIS_CIPHERED, "", "SUITES", "", "disabled cipher suites (comma separated list)"),
+            new Option(CON_SSL_ENA_PROTOS, "", "PROTOCOLS", "", "enabled protocols (comma separated list). No default, meaning the context default protocols are used"),
+            new Option(CON_SSL_DIS_PROTOS, "", "PROTOCOLS", "SSLv2Hello,SSLv3", "disabled protocols (comma separated list)"),
+            new Option(CON_SSL_TRUST_ALL, "", "ENABLED", "false", ""),
+            new Option(CON_SSL_VERIFY_HOST, "", "ENABLED", "true", ""),
+            new Option(CON_SSL_KEYALIAS, "", "ALIAS", "", "alias to use when selecting a keypair from the keystore if required to send a client certificate to the server"),
+
+            new Option(CON_TCP_SEND_BUF_SIZE, "", "SIZE", "64", "tcp send buffer size in kilobytes"),
+            new Option(CON_TCP_RECV_BUF_SIZE, "", "SIZE", "64", "tcp receive buffer size in kilobytes"),
+            new Option(CON_TCP_TRAFFIC_CLASS, "", "CLASS?", "0", "?tcp traffic class"),
+            new Option(CON_TCP_CON_TIMEOUT, "", "TIMEOUT", "60", "tcp connection timeout in seconds"),
+            new Option(CON_TCP_SOCK_TIMEOUT, "", "TIMEOUT", "-1", "?tcp socket timeout in (-1 disabled?)"),
+            new Option(CON_TCP_SOCK_LINGER, "", "TIMEOUT", "-1", "?tcp socket linger timeout"),
+            new Option(CON_TCP_KEEP_ALIVE, "", "ENABLED", "false", "send tcp keep alive packets"),
+            new Option(CONN_TCP_NO_DELAY, "", "ENABLED", "true", "use tcp_nodelay (automatic concatenation of small packets into bigger frames)"),
+
+            new Option(TRANSACTED, "", "ENABLED", "false", "whether the session is transacted or not"),
+            new Option(MSG_DURABLE, "false"),
+            new Option(DURATION, "0"),
+            new Option(FAILOVER_URL, ""),
+
+            new Option(MSG_CONTENT_HASHED, "", "", "false", "print the message content as a hash (SHA1)"),
+            new Option(MSG_CONTENT_STREAM, "", "", "false", "should the message be streamed, must be used with binary content on sender"),
+
+            new Option(CONN_USE_CONFIG_FILE, "", "jndi.properties", "false", "configure connection from JNDI .properties file"),
+
+            new Option(TRACE_MESSAGES, "", "false", "false", "sender|receiver will send traces to Jaeger agent on localhost"),
+
+            // OpenWire
+            new Option(CONN_SERVER_STACK_TRACE_ENA, "", "ENABLED", "true", "should the stack trace of exception that occur on the broker be sent to the client?"),
+            // tcpNoDelayEnabled (default true) is CONN_TCP_NO_DELAY
+            new Option(CONN_CACHE_ENA, "", "ENABLED", "true", "should commonly repeated values be cached so that less marshalling occurs?"),
+            new Option(CONN_TIGHT_ENCODING_ENA, "", "ENABLED", "true", "should wire size be optimized over CPU usage ?"),
+            new Option(CONN_PREFIX_PACKET_SIZE_ENA, "", "ENABLED", "true", "Should the size of the packet be prefixed before each packet is marshalled?"),
+            // maxInactivityDuration (ACtiveMQ default 30000ms) is CON_TCP_SOCK_TIMEOUT
+            new Option(CONN_MAX_INACTITVITY_DUR, "", "MS", "30000", "The maximum inactivity duration (after which the connection is considered dead) in seconds"),
+            new Option(CONN_MAX_INACTITVITY_DUR_INIT_DELAY, "", "MS", "10000", "initial delay before starting the maximum inactivity checks"),
+            new Option(CONN_CACHE_SIZE, "", "if CM_ENA=true", "1024", "if cacheEnabled is true, then this specifies the maximum number of values to cached. This property was added in ActiveMQ 4.1"),
+            new Option(CONN_MAX_FRAME_SIZE, "", "MAX_LONG", String.valueOf(Long.MAX_VALUE), "Maximum frame size that can be sent. Can help help prevent OOM DOS attacks"),
+            new Option(CONN_WATCH_TOPIC_ADVISORIES, "", "ENABLED", String.valueOf(true), "Whether to attach to OpenWire topic advisory addresses")
+        ));
+    }
+
+    /**
+     * Check whether this option is valid for client.
+     *
+     * @param option option name to look up in optionsMap
+     * @return true, if this option is valid for given client.
+     */
+
+    public boolean isValidOption(Option option) {
+        if (option == null) {
+            throw new IllegalArgumentException("Argument is null!");
+        }
+        return defaultOptions.contains(option);
+    }
+
+    /**
+     * Get defaultValue for given option.
+     *
+     * @param name get defaultValue for this option
+     * @return Object
+     */
+    public abstract Option getOption(String name);
+
+    /**
+     * Method for getting default values for given client.
+     *
+     * @return Map of default options for given client
+     */
+    public abstract List<Option> getClientDefaultOptions();
+
+    /**
+     * Get list of actual/updated client options.
+     *
+     * @return current list of updated client options
+     */
+    public abstract List<Option> getClientOptions();
+
+    public List<Option> getDefaultOptions() {
+        return defaultOptions;
+    }
+
+    /**
+     * Method returns the map of parsed (updated) client Options, without
+     * the default options.
+     * Map contains the mapping as optionName:Option.
+     * OptionName keys are all defined in ClientOptions class.
+     *
+     * @return map of option names and client Options which has been
+     * modified by the user command line input.
+     */
+    public Map<String, Option> getUpdatedOptionsMap() {
+        Map<String, Option> updatedOptionsMap = new HashMap<>();
+        for (Option option : updatedOptions) {
+            updatedOptionsMap.put(option.getName(), option);
+        }
+        return updatedOptionsMap;
+    }
+
+    public List<Option> getUpdatedOptions() {
+        return updatedOptions;
+    }
+
+    public void setUpdatedOptions(List<Option> updatedOptions) {
+        this.updatedOptions = updatedOptions;
+    }
+
+    public static void addNumericArgumentValueOptionList(Option option) {
+        numericArgumentValueOptionList.add(option);
+    }
+}
+

--- a/jakartalib/src/main/java/com/redhat/mqe/lib/ConnectionManager.java
+++ b/jakartalib/src/main/java/com/redhat/mqe/lib/ConnectionManager.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2017 Red Hat, Inc.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.redhat.mqe.lib;
+
+import jakarta.jms.Connection;
+import jakarta.jms.ConnectionFactory;
+import jakarta.jms.Destination;
+import jakarta.jms.Queue;
+import jakarta.jms.Topic;
+
+/**
+ * Subclasses are responsible for assigning to attributes
+ * factory, initialContext
+ * <p>
+ * TODO: clarify purpose of this class, now it looks like a factory for factory to me
+ * This class initializes attributes connection and destination,
+ * which will be pulled by the client.
+ * <p>
+ * session, creates queues and topics on that session and ?? sends messages?
+ */
+abstract public class ConnectionManager {
+    protected ConnectionFactory factory;
+    protected Connection connection;
+    protected Destination destination;
+    protected String password;
+    protected String username;
+    protected static final String QUEUE_OBJECT = "javax.jms.Queue";
+    protected static final String TOPIC_OBJECT = "javax.jms.Topic";
+
+    /**
+     * private static final String AMQ_INITIAL_CONTEXT = "org.apache.qpid.jms.jndi.JmsInitialContextFactory";
+     * private static final String QPID_INITIAL_CONTEXT = "org.apache.qpid.jndi.PropertiesFileInitialContextFactory";
+     * private static final String WIRE_INITIAL_CONTEXT = "org.apache.activemq.jndi.ActiveMQInitialContextFactory";
+     * private static final String ARTEMIS_INITIAL_CONTEXT = "org.apache.activemq.artemis.jndi.ActiveMQInitialContextFactory";
+     */
+
+    Connection getConnection() {
+        return this.connection;
+    }
+
+    Destination getDestination() {
+        return destination;
+    }
+
+    protected abstract Queue createQueue(String queueName);
+
+    protected abstract Topic createTopic(String topicName);
+}

--- a/jakartalib/src/main/java/com/redhat/mqe/lib/ConnectionManagerFactory.java
+++ b/jakartalib/src/main/java/com/redhat/mqe/lib/ConnectionManagerFactory.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2017 Red Hat, Inc.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.redhat.mqe.lib;
+
+public abstract class ConnectionManagerFactory {
+    protected abstract ConnectionManager make(ClientOptions clientOptions, String brokerUri);
+
+    protected ConnectionManager makeJndi(ClientOptions clientOptions, String brokerUri) {
+        return new JndiConnectionManager(clientOptions, brokerUri);
+    }
+}

--- a/jakartalib/src/main/java/com/redhat/mqe/lib/ConnectorClient.java
+++ b/jakartalib/src/main/java/com/redhat/mqe/lib/ConnectorClient.java
@@ -1,0 +1,167 @@
+/*
+ * Copyright (c) 2017 Red Hat, Inc.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.redhat.mqe.lib;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+import jakarta.jms.*;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * ConnectorClient is an Messaging QE client, which is able to
+ * create connections to provided brokers. Connector can create multiple
+ * Connection, Session, MessageProducer, MessageConsumer and TemporaryQueue objects.
+ * It can wait for given time
+ */
+public class ConnectorClient extends CoreClient {
+
+    private ClientOptions connectorOptions;
+    private int connectionsOpened = 0;
+    private static List<Throwable> exceptions = new ArrayList<>();
+
+    @Inject
+    public ConnectorClient(ConnectionManagerFactory connectionManagerFactory, JmsMessageFormatter jmsMessageFormatter, @Named("Connector") ClientOptions options) {
+        this.connectionManagerFactory = connectionManagerFactory;
+        this.jmsMessageFormatter = jmsMessageFormatter;
+        this.connectorOptions = options;
+    }
+
+
+    @Override
+    public void startClient() {
+        // start all connections
+        createConnectionObjects(connectorOptions.getOption(ClientOptions.OBJ_CTRL).getDefaultValue());
+        if (exceptions.isEmpty()) {
+            startConnections();
+        }
+
+        int count = Integer.parseInt((this.getClientOptions().getOption(ClientOptions.COUNT).getValue()));
+        jmsMessageFormatter.printConnectorStatistics(connectionsOpened, count - connectionsOpened, count);
+
+        for (Throwable t : exceptions) {
+            LOG.error(t.getMessage(), t.getCause());
+        }
+        closeConnObjects(this,
+            Double.parseDouble(this.getClientOptions().getOption(ClientOptions.CLOSE_SLEEP).getValue()));
+        if (exceptions.size() > 0) {
+            System.exit(exceptions.size());
+        }
+    }
+
+    /**
+     * Start connections created by ::createConnectionObject()
+     */
+    private void startConnections() {
+        for (Connection connection : this.getConnections()) {
+            try {
+                if (connection != null) {
+                    connection.start();
+                    connectionsOpened++;
+                }
+            } catch (JMSException e) {
+                exceptions.add(new MessagingException("Failed to start a connection.\n" + e.getMessage(), e.getCause()));
+            }
+        }
+        closeConnObjects(this,
+            Double.parseDouble(this.getClientOptions().getOption(ClientOptions.CLOSE_SLEEP).getValue()));
+    }
+
+
+    /**
+     * Create given number of Connection, Session, MessageProducer,
+     * MessageConsumer, TemporaryQueue objects.
+     *
+     * @param objCtrl specifies which objects are to be created
+     */
+    private void createConnectionObjects(String objCtrl) {
+        if (connectorOptions.getOption(ClientOptions.ADDRESS).hasParsedValue()) {
+            objCtrl = "CESR";
+        } else if (connectorOptions.getOption(ClientOptions.OBJ_CTRL).hasParsedValue()) {
+            objCtrl = connectorOptions.getOption(ClientOptions.OBJ_CTRL).getValue().toUpperCase();
+        }
+        int count = Integer.parseInt(connectorOptions.getOption(ClientOptions.COUNT).getValue());
+        try {
+            // create N Connections
+            for (int i = 0; i < count; i++) {
+                this.createConnection(connectorOptions);
+            }
+
+            // create N sEssions
+            if (objCtrl.contains("E")) {
+                for (Connection connection : getConnections()) {
+                    createSession(connectorOptions, connection, false);
+                }
+
+                Destination destination = null;
+                if (objCtrl.contains("S") || objCtrl.contains("R")) {
+                    destination = this.getDestination();
+                }
+                // create N Senders (MessageProducers)
+                if (objCtrl.contains("S")) {
+                    for (Session session : getSessions()) {
+                        MessageProducer producer = session.createProducer(destination);
+                        addMessageProducer(producer);
+                    }
+                    // create N Receivers (MessageConsumers)
+                }
+                if (objCtrl.contains("R")) {
+                    for (Session session : getSessions()) {
+                        MessageConsumer consumer = session.createConsumer(destination);
+                        addMessageConsumer(consumer);
+                    }
+                }
+                // create temporary queue (the only queue we can create with JMSSession)
+                if (objCtrl.contains("Q")) {
+                    int qCount = Integer.parseInt(connectorOptions.getOption(ClientOptions.Q_COUNT).getValue());
+                    if (qCount > count) {
+                        qCount = count;
+                    }
+                    for (Session session : getSessions()) {
+                        if (qCount > 0) {
+                            Queue queue = session.createTemporaryQueue();
+                            addQueue(queue);
+                            qCount--;
+                        } else {
+                            break;
+                        }
+                    }
+                }
+            }
+
+            if (LOG.isTraceEnabled()) {
+                int conns = (getConnections() == null) ? 0 : getConnections().size();
+                int sesss = (getSessions() == null) ? 0 : getSessions().size();
+                int sends = (getProducers() == null) ? 0 : getProducers().size();
+                int reces = (getConsumers() == null) ? 0 : getConsumers().size();
+                int queues = (getQueues() == null) ? 0 : getQueues().size();
+                LOG.trace("\tC={}\tE={}\tS={}\tR={}\tQ={}", conns, sesss, sends, reces, queues);
+            }
+        } catch (JMSException e) {
+            exceptions.add(new MessagingException("Failed to create 'obj-ctrl.\n" + e.getMessage(), e.getCause()));
+        }
+    }
+
+    @Override
+    ClientOptions getClientOptions() {
+        return connectorOptions;
+    }
+
+}

--- a/jakartalib/src/main/java/com/redhat/mqe/lib/ConnectorOptions.java
+++ b/jakartalib/src/main/java/com/redhat/mqe/lib/ConnectorOptions.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2017 Red Hat, Inc.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.redhat.mqe.lib;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.inject.Inject;
+import java.util.Arrays;
+import java.util.LinkedList;
+import java.util.List;
+
+/**
+ * Default options for ConnectorClient.
+ */
+public class ConnectorOptions extends ClientOptions {
+    private List<Option> options = new LinkedList<Option>();
+    private Logger LOG = LoggerFactory.getLogger(ReceiverOptions.class);
+    private final List<Option> connectorDefaultOptions = new LinkedList<Option>();
+
+    {
+        connectorDefaultOptions.addAll(Arrays.asList(
+            new Option(ADDRESS, "a", "CCADDRESS", "?", "If specified the C senders and receivers are created for this address"),
+            new Option(OBJ_CTRL, "", "OBJCTRL", "C", "Optional creation object control (syntax C/E/S/R stands for Connection, sEssion, Sender, Receiver)"),
+            new Option(COUNT, "c", "CONNCOUNT", "1", "Specify how many connections will make"),
+            // TODO JMS+SYNC_MODE?
+            new Option(SYNC_MODE, "", "SMODE", "action", "Optional action synchronization mode: none/session/action (JMS does not support none & session modes)")
+        ));
+    }
+
+    @Inject
+    public ConnectorOptions() {
+        this.options = ClientOptionManager.mergeOptionLists(super.getDefaultOptions(), connectorDefaultOptions);
+    }
+
+    @Override
+    public Option getOption(String name) {
+        if (name != null) {
+            for (Option option : options) {
+                if (name.equals(option.getName()))
+                    return option;
+            }
+        } else {
+            LOG.error("Accessing client options map with null key.");
+            throw new IllegalArgumentException("Null name is not allowed!");
+        }
+        return null;
+    }
+
+    @Override
+    public List<Option> getClientDefaultOptions() {
+        return connectorDefaultOptions;
+    }
+
+    @Override
+    public List<Option> getClientOptions() {
+        return options;
+    }
+
+    @Override
+    public String toString() {
+        return "ConnectorOptions{" +
+            "options=" + options +
+            '}';
+    }
+    /**
+     -h, --help                                            show this help message and exit
+     -b USER/PASS@HOST:PORT, --broker USER/PASS@HOST:PORT  connect to specified broker (default guest/guest@localhost:5672)
+     --duration DURATION                                   Opened objects will be held until duration passes by, Also the sessions if exists will be synced every T=1s (default 0)
+     -a CCADDRESS, --address CCADDRESS                     If specified the C senders and receivers are created for this address (default )
+     --obj-ctrl OBJCTRL                                    Optional creation object control (syntax C/E/S/R stands for Connection, sEssion, Sender, Receiver) (default C)
+     --sync-mode SMODE                                     Optional action synchronization mode: none/session/action (JMS does not support none & session modes) (default action)
+     -c CONN_CNT, --conn-cnt CONN_CNT                      Specify how many connections will make (default 1)
+     --con-option NAME=VALUE                               JMS Connection URL options. Ex sync_ack=true sync_publish=all
+     --broker-option NAME=VALUE                            JMS Broker URL options. Ex ssl=true sasl_mechs=GSSAPI
+     --connection-options {NAME=VALUE,NAME=VALUE..}        QPID Connection URL options. (c++ style)
+     */
+}

--- a/jakartalib/src/main/java/com/redhat/mqe/lib/CoreClient.java
+++ b/jakartalib/src/main/java/com/redhat/mqe/lib/CoreClient.java
@@ -1,0 +1,486 @@
+/*
+ * Copyright (c) 2017 Red Hat, Inc.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.redhat.mqe.lib;
+
+import com.redhat.mqe.ClientListener;
+import org.jetbrains.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.inject.Inject;
+import jakarta.jms.Connection;
+import jakarta.jms.Destination;
+import jakarta.jms.JMSException;
+import jakarta.jms.Message;
+import jakarta.jms.MessageConsumer;
+import jakarta.jms.MessageProducer;
+import jakarta.jms.Queue;
+import jakarta.jms.Session;
+import java.net.SocketException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+//import javax.ws.rs.core.UriBuilder;  // helpful class that would sadly require bringing in additional dependency
+
+
+/**
+ * Core implementation of creating various connections to brokers using clients.
+ */
+public abstract class CoreClient {
+    protected static Logger LOG = LoggerFactory.getLogger(CoreClient.class);
+    private ConnectionManager connectionManager;
+    private static final Map<String, Integer> SESSION_ACK_MAP = new HashMap<>(5);
+
+    static {
+//    SESSION_ACK_MAP.put("transacted", Session.SESSION_TRANSACTED); // This is handled by TRANSACTED option
+        SESSION_ACK_MAP.put("auto", Session.AUTO_ACKNOWLEDGE);
+        SESSION_ACK_MAP.put("client", Session.CLIENT_ACKNOWLEDGE);
+        SESSION_ACK_MAP.put("dups_ok", Session.DUPS_OK_ACKNOWLEDGE);
+//    SESSION_ACK_MAP.put("individual", Session.INDIVIDUAL_ACKNOWLEDGE); // ActiveMQSpecific?
+    }
+
+    private List<Connection> connections;
+    private List<Session> sessions;
+    private List<MessageProducer> messageProducers;
+    private List<MessageConsumer> messageConsumers;
+    private List<Queue> queues;
+
+    protected ConnectionManagerFactory connectionManagerFactory;
+    protected JmsMessageFormatter jmsMessageFormatter;
+
+    @Inject
+    @Nullable
+    protected ClientListener listener;
+
+    /**
+     * Method starts the given client. Serves as entry point.
+     */
+    public abstract void startClient() throws Exception;
+
+    /**
+     * Create @Connection for given client from provided client options.
+     * By default, we prefer to use brokerUrl to not set up anything.
+     * Also, no brokerUrl can be provided, but we need all the other connection
+     * options to create @Connection.
+     *
+     * @param clientOptions options of given client
+     * @return newly created Connection from provided client options
+     */
+    public Connection createConnection(ClientOptions clientOptions) {
+//    Map<String, Option> updatedOptions = clientOptions.getUpdatedOptions();
+        String brokerUrl;
+        if (clientOptions.getOption(ClientOptions.BROKER_URI).hasParsedValue()) {
+            // Use the whole provided broker-url string with options
+            brokerUrl = clientOptions.getOption(ClientOptions.BROKER_URI).getValue();
+        } else {
+            // Use only protocol,credentials,host and port
+            brokerUrl = clientOptions.getOption(ClientOptions.BROKER).getValue();
+            if (clientOptions.getOption(ClientOptions.BROKER_OPTIONS).hasParsedValue()) {
+                brokerUrl += "?" + clientOptions.getOption(ClientOptions.BROKER_OPTIONS).getValue();
+            }
+        }
+
+        if (clientOptions.getOption(ClientOptions.CONN_USE_CONFIG_FILE).hasParsedValue()) {
+            connectionManager = connectionManagerFactory.makeJndi(clientOptions, brokerUrl);
+        } else {
+            connectionManager = connectionManagerFactory.make(clientOptions, brokerUrl);
+        }
+        Connection connection = connectionManager.getConnection();
+        addConnection(connection);
+        return connection;
+    }
+
+    /**
+     * Abstract method, returns the current client Options.
+     *
+     * @return the given ClientOption list
+     */
+    abstract ClientOptions getClientOptions();
+
+    /**
+     * Create session for  client on provided connection using clientOptions
+     *
+     * @param clientOptions options of the client
+     * @param connection    to be created session on
+     * @param transacted    defines whether create transacted session or not
+     * @return created session object
+     */
+    protected Session createSession(ClientOptions clientOptions, Connection connection, boolean transacted) {
+        Session session = null;
+//    boolean transacted = Boolean.parseBoolean(clientOptions.getOption(ClientOptions.TRANSACTED).getValue());
+        int acknowledgeMode = SESSION_ACK_MAP.get(clientOptions.getOption(ClientOptions.SSN_ACK_MODE).getValue());
+        try {
+            // if transacted is true, acknowledgeMode is ignored
+            session = connection.createSession(transacted, acknowledgeMode);
+        } catch (JMSException e) {
+            LOG.error("Error while creating session! " + e.getMessage());
+            e.printStackTrace();
+            System.exit(1);
+        }
+        if (sessions == null) {
+            sessions = new ArrayList<>();
+        }
+        sessions.add(session);
+        return session;
+    }
+
+    protected Destination getDestination() {
+        return this.connectionManager.getDestination();
+    }
+
+    String getDestinationType() {
+        return getClientOptions().getOption(ClientOptions.DESTINATION_TYPE).getValue();
+    }
+
+    /**
+     * Returns the list of connections for this client
+     *
+     * @return list of Connections
+     */
+    List<Connection> getConnections() {
+        return connections;
+    }
+
+    /**
+     * After creation of new connection, this connection
+     * is automatically added to the list of connections.
+     * No need to use it explicitly.
+     *
+     * @param connection to be added to the list
+     */
+    void addConnection(Connection connection) {
+        if (connections == null) {
+            connections = new ArrayList<>(getCount());
+        }
+        connections.add(connection);
+    }
+
+    /**
+     * Returns the list of sessions for this client
+     *
+     * @return list of Sessions
+     */
+    List<Session> getSessions() {
+        return sessions;
+    }
+
+    /**
+     * Add this session to the list of sessions.
+     *
+     * @param session to be added to session list
+     */
+    void addSession(Session session) {
+        if (sessions == null) {
+            sessions = new ArrayList<>(getCount());
+        }
+        sessions.add(session);
+    }
+
+    /**
+     * Returns the list of MessageProducers for this client
+     *
+     * @return list of MessageProducers
+     */
+    List<MessageProducer> getProducers() {
+        return messageProducers;
+    }
+
+    /**
+     * Add this producer to the list of messageProducers.
+     *
+     * @param messageProducer to be added to messageProducers list
+     */
+    void addMessageProducer(MessageProducer messageProducer) {
+        if (messageProducers == null) {
+            messageProducers = new ArrayList<>(getCount());
+        }
+        messageProducers.add(messageProducer);
+    }
+
+    /**
+     * Returns the list of MessageConsumers for this client
+     *
+     * @return list of MessageConsumers
+     */
+    List<MessageConsumer> getConsumers() {
+        return messageConsumers;
+    }
+
+    /**
+     * Add this consumer to the list of messageConsumer.
+     *
+     * @param messageConsumer to be added to messageConsumers list
+     */
+    void addMessageConsumer(MessageConsumer messageConsumer) {
+        if (messageConsumers == null) {
+            messageConsumers = new ArrayList<>(getCount());
+        }
+        messageConsumers.add(messageConsumer);
+    }
+
+    /**
+     * Add given queue to queues list
+     *
+     * @param queue to be added to queues list
+     */
+    void addQueue(Queue queue) {
+        if (queues == null) {
+            queues = new ArrayList<>(getCount());
+        }
+        queues.add(queue);
+    }
+
+    /**
+     * Returns the list of queues added
+     *
+     * @return queues added
+     */
+    public List<Queue> getQueues() {
+        return queues;
+    }
+
+    /**
+     * Returns the number of "count" argument.
+     *
+     * @return number of messages/connections depending on client
+     */
+    int getCount() {
+        return Integer.parseInt(getClientOptions().getOption(ClientOptions.COUNT).getValue());
+    }
+
+    /**
+     * Close objects for given Client.
+     * Sleep for given period of time before closing MessageProducer/Consumer,
+     * Session and Connection.
+     *
+     * @param client     holding all the open connection objects
+     * @param closeSleep sleep for given period of time between closings objects
+     */
+    protected static void closeConnObjects(CoreClient client, double closeSleep) {
+        long sleepMs = Math.round(closeSleep * 1000);
+        if (client.getProducers() != null) {
+            if (closeSleep > 0) {
+                LOG.debug("Sleeping before closing producers for " + closeSleep + " seconds.");
+                Utils.sleep(sleepMs);
+            }
+            for (MessageProducer producer : client.getProducers()) {
+                client.close(producer);
+            }
+        }
+
+        if (client.getConsumers() != null) {
+            if (closeSleep > 0) {
+                LOG.debug("Sleeping before closing consumers for " + closeSleep + " seconds.");
+                Utils.sleep(sleepMs);
+            }
+            for (MessageConsumer consumer : client.getConsumers()) {
+                client.close(consumer);
+            }
+        }
+
+        if (client.getSessions() != null) {
+            if (closeSleep > 0) {
+                LOG.debug("Sleeping before closing sessions for " + closeSleep + " seconds.");
+                Utils.sleep(sleepMs);
+            }
+            for (Session session : client.getSessions()) {
+                client.close(session);
+            }
+        }
+
+        if (closeSleep > 0) {
+            LOG.debug("Sleeping before closing connections for " + closeSleep + " seconds.");
+            Utils.sleep(sleepMs);
+        }
+        for (Connection connection : client.getConnections()) {
+            client.close(connection);
+        }
+    }
+
+    protected void close(Connection connection) {
+        try {
+            if (connection != null) {
+                LOG.trace("Closing connection " + connection.toString());
+                connection.close();
+            }
+        } catch (JMSException e) {
+            e.printStackTrace();
+            if (e.getCause() instanceof SocketException
+                && e.getCause().getMessage().equals("Connection closed by remote host")) {
+                return;  // suppress error, explained at https://issues.apache.org/jira/browse/AMQ-6956
+            }
+            System.exit(1);
+        }
+    }
+
+    protected void close(Session session) {
+        try {
+            LOG.trace("Closing session " + session.toString());
+            session.close();
+        } catch (JMSException e) {
+            e.printStackTrace();
+            if (getClientOptions().getOption(ClientOptions.CON_IGNORE_REMOTE_CLOSE).getValue().toLowerCase().equals("true")
+                && e.getClass().getName().toString().equals("org.apache.qpid.jms.JmsConnectionRemotelyClosedException")) {
+                return;  // suppress error, explained at https://issues.redhat.com/browse/MSGQE-8155
+            }
+            System.exit(1);
+        }
+    }
+
+    protected void close(MessageProducer messageProducer) {
+        try {
+            LOG.trace("Closing sender " + messageProducer.toString());
+            messageProducer.close();
+        } catch (JMSException e) {
+            e.printStackTrace();
+            System.exit(1);
+        }
+    }
+
+    protected void close(MessageConsumer messageConsumer) {
+        try {
+            LOG.trace("Closing receiver " + messageConsumer.toString());
+            messageConsumer.close();
+        } catch (JMSException e) {
+            e.printStackTrace();
+            System.exit(1);
+        }
+    }
+
+    /**
+     * Print message using JmsMessageFormatter in given format.
+     * Printing format is specified using LOG_MSGS value
+     * as (dict|body|upstream|none).
+     *
+     * @param clientOptions options of the client
+     * @param message       to be printed
+     */
+    protected void printMessage(ClientOptions clientOptions, Message message) {
+        final String logMsgs = clientOptions.getOption(ClientOptions.LOG_MSGS).getValue();
+        final String out = clientOptions.getOption(ClientOptions.OUT).getValue();
+        boolean hashContent = Boolean.valueOf(clientOptions.getOption(ClientOptions.MSG_CONTENT_HASHED).getValue());
+        Map<String, Object> messageData = null;
+        try {
+            switch (logMsgs) {
+                case "dict":
+                    messageData = jmsMessageFormatter.formatMessageAsDict(message, hashContent);
+                    break;
+                case "body":
+                    messageData = jmsMessageFormatter.formatMessageBody(message, hashContent);
+                    break;
+                case "interop":
+                case "json":
+                    messageData = jmsMessageFormatter.formatMessageAsInterop(message, hashContent);
+                    break;
+                case "none":
+                default:
+                    break;
+            }
+        } catch (JMSException e) {
+            LOG.error("Unable to retrieve text from message.\n" + e.getMessage());
+            e.printStackTrace();
+            System.exit(1);
+        }
+        if (messageData != null) {
+            if (listener != null) {
+                listener.onMessage(messageData);
+            }
+            if ("json".equals(logMsgs) || "json".equals(out)) {
+                jmsMessageFormatter.printMessageAsJson(messageData);
+            } else {
+                jmsMessageFormatter.printMessageAsPython(messageData);
+            }
+        }
+    }
+
+    /**
+     * Do the given transaction.
+     *
+     * @param session     to do transaction on this session
+     * @param transaction transaction action type to perform
+     */
+    protected static void doTransaction(Session session, String transaction) {
+        try {
+            StringBuilder txLog = new StringBuilder("Performed ");
+            switch (transaction.toLowerCase()) {
+                case "commit":
+                    session.commit();
+                    txLog.append("Commit");
+                    break;
+                case "rollback":
+                    session.rollback();
+                    txLog.append("Rollback");
+                    break;
+                case "recover":
+                    session.recover();
+                    txLog.append("Recover");
+                    break;
+                case "none":
+                    txLog.append("None");
+                    break;
+                default:
+                    LOG.error("Unknown tx action: '" + transaction + "'! Exiting");
+                    System.exit(2);
+            }
+            LOG.trace(txLog.append(" TX action").toString());
+        } catch (JMSException e) {
+            e.printStackTrace();
+        }
+    }
+
+    /**
+     * Set global options applicable to all clients.
+     * Only Logging for now.
+     *
+     * @param clientOptions options of the client
+     */
+    protected static void setGlobalClientOptions(ClientOptions clientOptions) {
+        if (clientOptions.getOption(ClientOptions.LOG_LEVEL).hasParsedValue()) {
+            Utils.setLogLevel(clientOptions.getOption(ClientOptions.LOG_LEVEL).getValue());
+        }
+    }
+
+    /**
+     * Format broker connection strictly for 'broker' argument.
+     * Url consists of protocol, (username+password), hostname and port.
+     *
+     * @param clientOptions
+     * @return
+     */
+    static String formBrokerUrl(ClientOptions clientOptions) {
+        StringBuilder brkCon = new StringBuilder();
+        if (!clientOptions.getOption(ClientOptions.PROTOCOL).getValue().equals("")) {
+            brkCon.append(clientOptions.getOption(ClientOptions.PROTOCOL).getValue()).append(":");
+        }
+
+        if (clientOptions.getOption(ClientOptions.FAILOVER_URL).hasParsedValue()) {
+                brkCon.append("(");
+                brkCon.append(clientOptions.getOption(ClientOptions.FAILOVER_URL).getValue()).append(")");
+        } else {
+            brkCon.append("//");
+            brkCon.append(clientOptions.getOption(ClientOptions.BROKER_HOST).getValue()).append(":")
+                .append(clientOptions.getOption(ClientOptions.BROKER_PORT).getValue());
+        }
+        LOG.trace("BrokerUrl=" + brkCon.toString());
+        return brkCon.toString();
+    }
+}

--- a/jakartalib/src/main/java/com/redhat/mqe/lib/CoreJmsMessageFormatter.java
+++ b/jakartalib/src/main/java/com/redhat/mqe/lib/CoreJmsMessageFormatter.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2017 Red Hat, Inc.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.redhat.mqe.lib;
+
+import jakarta.jms.JMSException;
+import jakarta.jms.Message;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Message output formatter to python dict,
+ * map, or any other object printable format.
+ * Reusable from old client
+ */
+public class CoreJmsMessageFormatter extends JmsMessageFormatter {
+    /**
+     * Openwire -> AMQP mapping http://activemq.apache.org/amqp.html
+     */
+    @SuppressWarnings("unchecked")
+    public Map<String, Object> formatMessage(Message msg, boolean hashContent) throws JMSException {
+        Map<String, Object> result = new HashMap<>();
+        addFormatJMS11(msg, result, hashContent);
+        addFormatJMS20(msg, result);
+        return result;
+    }
+}

--- a/jakartalib/src/main/java/com/redhat/mqe/lib/JmsMessageFormatter.java
+++ b/jakartalib/src/main/java/com/redhat/mqe/lib/JmsMessageFormatter.java
@@ -1,0 +1,290 @@
+/*
+ * Copyright (c) 2017 Red Hat, Inc.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.redhat.mqe.lib;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import jakarta.jms.BytesMessage;
+import jakarta.jms.DeliveryMode;
+import jakarta.jms.Destination;
+import jakarta.jms.JMSException;
+import jakarta.jms.MapMessage;
+import jakarta.jms.Message;
+import jakarta.jms.MessageEOFException;
+import jakarta.jms.MessageFormatException;
+import jakarta.jms.ObjectMessage;
+import jakarta.jms.StreamMessage;
+import jakarta.jms.TextMessage;
+import java.math.BigInteger;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.ArrayList;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * JmsMessageFormatter abstraction layer for all protocols.
+ * <p>
+ * Subclasses of JmsMessageFormatter produce data structures containing message data. Use the Formatter classes to print as Python objects,
+ * JSON, and so on.
+ */
+public abstract class JmsMessageFormatter extends MessageFormatter {
+    static Logger LOG = LoggerFactory.getLogger(JmsMessageFormatter.class);
+
+    String AMQP_CONTENT_TYPE = "JMS_AMQP_ContentType";
+    String OWIRE_AMQP_FIRST_ACQUIRER = "JMS_AMQP_FirstAcquirer";
+    String OWIRE_AMQP_SUBJECT = "JMS_AMQP_Subject";
+    String OWIRE_AMQP_CONTENT_ENCODING = "JMS_AMQP_ContentEncoding";
+    String OWIRE_AMQP_REPLY_TO_GROUP_ID = "JMS_AMQP_ReplyToGroupID";
+    String AMQP_JMSX_GROUP_SEQ = "JMSXGroupSeq";
+    String JMSX_DELIVERY_COUNT = "JMSXDeliveryCount";
+    String JMSX_USER_ID = "JMSXUserID";
+    String JMSX_GROUP_ID = "JMSXGroupID";
+
+    /**
+     * Print message body as text.
+     */
+    public Map<String, Object> formatMessageBody(Message message, boolean hashContent) {
+        String content = null;
+        if (message instanceof TextMessage) {
+            TextMessage textMessage = (TextMessage) message;
+            try {
+                content = textMessage.getText();
+            } catch (JMSException e) {
+                LOG.error("Unable to retrieve text from message.\n" + e.getMessage());
+                e.printStackTrace();
+                System.exit(1);
+            }
+        }
+
+        Map<String, Object> messageData = new HashMap<>();
+        messageData.put("content", hashContent ? hash(content) : content);
+        return messageData;
+    }
+
+    /**
+     * Returns a Map that is a common foundation for Dict and Interop outputs
+     */
+    public abstract Map<String, Object> formatMessage(Message msg, boolean hashContent) throws JMSException;
+
+    public void addFormatInterop(Message msg, Map<String, Object> result) throws JMSException {
+        result.put("delivery-count", subtractJMSDeliveryCount(msg.getIntProperty(JMSX_DELIVERY_COUNT)));
+        result.put("first-acquirer", msg.getBooleanProperty(OWIRE_AMQP_FIRST_ACQUIRER));
+    }
+
+    public void addFormatJMS11(Message msg, Map<String, Object> result, boolean hashContent) throws JMSException {
+        // Header
+        result.put("durable", msg.getJMSDeliveryMode() == DeliveryMode.PERSISTENT);
+        result.put("priority", msg.getJMSPriority());
+        result.put("ttl", JmsUtils.getTtl(msg));
+
+        // Delivery Annotations
+
+        // Properties
+        result.put("id", removeIDprefix(msg.getJMSMessageID()));
+        result.put("user-id", msg.getStringProperty(JMSX_USER_ID));
+        result.put("address", formatAddress(msg.getJMSDestination()));
+        result.put("subject", msg.getObjectProperty(OWIRE_AMQP_SUBJECT));
+        result.put("reply-to", formatAddress(msg.getJMSReplyTo()));
+        result.put("correlation-id", removeIDprefix(msg.getJMSCorrelationID()));
+        result.put("content-type", msg.getStringProperty(AMQP_CONTENT_TYPE));
+        result.put("content-encoding", msg.getStringProperty(OWIRE_AMQP_CONTENT_ENCODING));
+        result.put("absolute-expiry-time", msg.getJMSExpiration());
+        result.put("creation-time", msg.getJMSTimestamp());
+        result.put("group-id", msg.getStringProperty(JMSX_GROUP_ID));
+        result.put("group-sequence", getGroupSequenceNumber(msg, AMQP_JMSX_GROUP_SEQ));
+        result.put("reply-to-group-id", msg.getStringProperty(OWIRE_AMQP_REPLY_TO_GROUP_ID));
+
+        // Application Properties
+        result.put("properties", formatProperties(msg));
+
+        // Application Data
+        result.put("content", hashContent ? hash(formatContent(msg)) : formatContent(msg));
+        result.put("type", msg.getJMSType()); // not everywhere, amqp does not have it
+    }
+
+    public void addFormatJMS20(Message msg, Map<String, Object> result) throws JMSException {
+        // Delivery Annotations
+        result.put("redelivered", msg.getJMSRedelivered());
+        result.put("delivery-time", msg.getJMSDeliveryTime());
+    }
+
+    /**
+     * Print message with as many as possible known client properties.
+     */
+    public Map<String, Object> formatMessageAsDict(Message msg, boolean hashContent) throws JMSException {
+        Map<String, Object> result = formatMessage(msg, hashContent);
+        result.put("redelivered", msg.getJMSRedelivered());
+        return result;
+    }
+
+    /**
+     * Print message in interoperable way for comparing with other clients.
+     */
+    public Map<String, Object> formatMessageAsInterop(Message msg, boolean hashContent) throws JMSException {
+        Map<String, Object> result = formatMessage(msg, hashContent);
+        addFormatInterop(msg, result);
+        result.put("id", removeIDprefix((String) result.get("id")));
+        result.put("user-id", removeIDprefix((String) result.get("user-id")));
+        result.put("correlation-id", removeIDprefix((String) result.get("correlation-id")));
+        result.put("group-sequence", changeMinusOneToZero((long) result.get("group-sequence")));
+        return result;
+    }
+
+    protected long getGroupSequenceNumber(Message message, String propertyName) {
+        try {
+            if (message.getStringProperty(propertyName) == null) {
+                return 0;
+            } else {
+                return message.getLongProperty(propertyName);  // it is UnsignedInteger in qpid-jms; ActiveMQ uses -1
+            }
+        } catch (JMSException e) {
+            e.printStackTrace();
+        }
+        return 0;
+    }
+
+    protected String dropDestinationPrefix(String destination) {
+        if (destination == null) {
+            return null;
+        }
+        if (destination.startsWith(ClientOptionManager.TOPIC_PREFIX)
+            || destination.startsWith(ClientOptionManager.QUEUE_PREFIX)) {
+            return destination.substring(ClientOptionManager.TOPIC_PREFIX.length());
+        }
+        return destination;
+    }
+
+    /**
+     * Method removes "ID:" prefix from various JMS message IDs.
+     * This should be used only with interoperability formatting.
+     */
+    protected String removeIDprefix(String in_data) {
+        if (in_data != null) {
+            if (in_data.startsWith("ID:")) {
+                in_data = in_data.substring(3);
+            }
+        }
+        return in_data;
+    }
+
+    protected long changeMinusOneToZero(long n) {
+        if (n == -1) {
+            return 0;
+        }
+        return n;
+    }
+
+    protected String formatAddress(Destination destination) {
+        if (destination == null) {
+            return null;
+        }
+
+        final String address = destination.toString();
+        return dropDestinationPrefix(address);
+    }
+
+    @SuppressWarnings("unchecked")
+    protected Map<String, Object> formatProperties(Message msg) {
+        Map<String, Object> format = new HashMap<>();
+        try {
+            Enumeration<String> props = msg.getPropertyNames();
+            String pVal;
+
+            while (props.hasMoreElements()) {
+                pVal = props.nextElement();
+                format.put(pVal, msg.getObjectProperty(pVal));
+            }
+        } catch (JMSException jmse) {
+            LOG.error("Error while getting message properties!", jmse.getMessage());
+            jmse.printStackTrace();
+            System.exit(1);
+        }
+        return format;
+    }
+
+    @SuppressWarnings("unchecked")
+    protected Map<String, Object> extractMap(MapMessage msg) {
+        Map<String, Object> map = new HashMap<String, Object>();
+        try {
+            Enumeration<String> e = msg.getMapNames();
+            while (e.hasMoreElements()) {
+                String name = e.nextElement();
+                Object obj;
+                try {
+                    if (msg instanceof BytesMessage) {
+                        obj = new String(msg.getBytes(name));
+                    } else {
+                        obj = msg.getObject(name);
+                    }
+                } catch (MessageFormatException exc) {
+                    obj = msg.getObject(name);
+                }
+                map.put(name, obj);
+            }
+        } catch (JMSException jmse) {
+            LOG.error("Error while extracting MapMessage!");
+            jmse.printStackTrace();
+            System.exit(1);
+        }
+        return map;
+    }
+
+    @SuppressWarnings("unchecked")
+    protected Object formatContent(Message msg) {
+        try {
+            if (msg instanceof TextMessage) {
+                return ((TextMessage) msg).getText();
+            } else if (msg instanceof MapMessage) {
+                return extractMap((MapMessage) msg);
+            } else if (msg instanceof ObjectMessage) {
+                return ((ObjectMessage) msg).getObject();
+            } else if (msg instanceof BytesMessage) {
+                BytesMessage bmsg = (BytesMessage) msg;
+                if (bmsg.getBodyLength() > 0) {
+                    byte[] readBytes = new byte[(int) bmsg.getBodyLength()];
+                    bmsg.readBytes(readBytes);
+                    return readBytes.toString();
+//          return new StringBuilder(bmsg.readUTF());
+//          return new StringBuilder(new String(readBytes));
+                }
+            } else if (msg instanceof StreamMessage) {
+                StreamMessage streamMessage = (StreamMessage) msg;
+                List<Object> list = new ArrayList<>();
+                while (true) {
+                    try {
+                        Object o = streamMessage.readObject();
+                        list.add(o);
+                    } catch (MessageEOFException e) {
+                        return list;
+                    }
+                }
+            }
+        } catch (JMSException ex) {
+            LOG.error("Error while printing content from message");
+            ex.printStackTrace();
+            System.exit(1);
+        }
+        return null;
+    }
+}

--- a/jakartalib/src/main/java/com/redhat/mqe/lib/JmsUtils.java
+++ b/jakartalib/src/main/java/com/redhat/mqe/lib/JmsUtils.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright (c) 2021 Red Hat, Inc.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.redhat.mqe.lib;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import jakarta.jms.BytesMessage;
+import jakarta.jms.JMSException;
+import jakarta.jms.Message;
+import jakarta.jms.StreamMessage;
+import jakarta.jms.TextMessage;
+import java.io.BufferedOutputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.ObjectOutputStream;
+
+public class JmsUtils {
+    private static final Logger LOG = LoggerFactory.getLogger(Utils.class);
+
+    /**
+     * Calculate TTL of given message from message
+     * expiration time and message timestamp.
+     * <p/>
+     * Returns the time the message expires, which is the sum of the time-to-live value
+     * specified by the client and the GMT at the time of the send
+     * EXP_TIME = CLIENT_SEND+TTL (CLIENT_SEND??)
+     * CLIENT_SEND time is approximately getJMSTimestamp() (time value between send()/publish() and return)
+     * TODO - check for correctness
+     *
+     * @param message calculate TTL for this message
+     * @return positive long number if TTL was calculated. Long.MIN_VALUE if error.
+     */
+    public static long getTtl(Message message) {
+        long ttl = 0;
+        try {
+            long expiration = message.getJMSExpiration();
+            long timestamp = message.getJMSTimestamp();
+            if (expiration != 0 && timestamp != 0) {
+                ttl = expiration - timestamp;
+            }
+        } catch (JMSException jmse) {
+            LOG.error("Error while calculating TTL value.\n" + jmse.getMessage());
+            jmse.printStackTrace();
+            System.exit(1);
+        }
+        return ttl;
+    }
+
+    public static void streamMessageContentToFile(String filePath, Message message, int msgCounter) {
+        try {
+            File outputFile = getFilePath(filePath, msgCounter);
+            try (FileOutputStream fileOutputStream = new FileOutputStream(outputFile);
+                 BufferedOutputStream bufferedOutput = new BufferedOutputStream(fileOutputStream)) {
+//                final String saveStream = "JMS_AMQ_SaveStream";
+                final String saveStream = "JMS_AMQ_OutputStream";
+                message.setObjectProperty(saveStream, bufferedOutput);
+            }
+        } catch (IOException e) {
+            LOG.error("Error while writing to file '" + filePath + "'.");
+            e.printStackTrace();
+        } catch (JMSException e) {
+            e.printStackTrace();
+        }
+    }
+
+    static File getFilePath(String filePath, int msgCounter) throws IOException {
+        File file;
+        if (filePath == null || filePath.equals("")) {
+            file = File.createTempFile("recv_msg_", Long.toString(System.currentTimeMillis()));
+        } else {
+            file = new File(filePath + "_" + msgCounter);
+        }
+        return file;
+    }
+
+    /**
+     * Write message body (text or binary) to provided file or default one in temp directory.
+     *
+     * @param filePath file to write data to
+     * @param message  to be read and written to provided file
+     */
+    public static void writeMessageContentToFile(String filePath, Message message, int msgCounter) {
+        byte[] readByteArray;
+        try {
+            File file;
+            file = getFilePath(filePath, msgCounter);
+
+            LOG.debug("Write message content to file '" + file.getPath() + "'.");
+            if (message instanceof BytesMessage) {
+                LOG.debug("Writing BytesMessage to file");
+                BytesMessage bm = (BytesMessage) message;
+                readByteArray = new byte[(int) bm.getBodyLength()];
+                bm.reset(); // added to be able to read message content
+                bm.readBytes(readByteArray);
+                try (FileOutputStream fos = new FileOutputStream(file)) {
+                    fos.write(readByteArray);
+                }
+            } else if (message instanceof StreamMessage) {
+                LOG.debug("Writing StreamMessage to file");
+                StreamMessage sm = (StreamMessage) message;
+//        sm.reset(); TODO haven't tested this one
+                ByteArrayOutputStream baos = new ByteArrayOutputStream();
+                ObjectOutputStream oos = new ObjectOutputStream(baos);
+                oos.writeObject(sm.readObject());
+                oos.close();
+            } else if (message instanceof TextMessage) {
+                LOG.debug("Writing TextMessage to file");
+                try (FileWriter fileWriter = new FileWriter(file)) {
+                    TextMessage tm = (TextMessage) message;
+                    fileWriter.write(tm.getText());
+                }
+            }
+        } catch (JMSException e) {
+            e.printStackTrace();
+        } catch (IOException e1) {
+            LOG.error("Error while writing to file '" + filePath + "'.");
+            e1.printStackTrace();
+        }
+    }
+}

--- a/jakartalib/src/main/java/com/redhat/mqe/lib/JndiConnectionManager.java
+++ b/jakartalib/src/main/java/com/redhat/mqe/lib/JndiConnectionManager.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2019 Red Hat, Inc.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.redhat.mqe.lib;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import jakarta.jms.ConnectionFactory;
+import jakarta.jms.JMSException;
+import jakarta.jms.Queue;
+import jakarta.jms.Topic;
+import javax.naming.Context;
+import javax.naming.NamingException;
+import java.util.Hashtable;
+
+public class JndiConnectionManager extends ConnectionManager {
+    private Logger LOG = LoggerFactory.getLogger(JndiConnectionManager.class.getName());
+    private Context context = null;
+
+    JndiConnectionManager(ClientOptions clientOptions, String brokerUrl) {
+        try {
+            Hashtable<String, String> environment = new Hashtable<>();
+            Option configureFromFile = clientOptions.getOption(ClientOptions.CONN_USE_CONFIG_FILE);
+            if (configureFromFile.hasParsedValue() && !configureFromFile.getValue().equals("true")) {
+                environment.put(Context.PROVIDER_URL, configureFromFile.getValue());
+            }
+
+            context = new javax.naming.InitialContext(environment);
+            destination = createQueue(clientOptions.getOption(ClientOptions.ADDRESS).getValue());
+            factory = (ConnectionFactory) lookup("amqFactory");
+            connection = factory.createConnection();
+        } catch (NamingException | JMSException e) {
+            LOG.error(e.getMessage());
+            e.printStackTrace();
+        }
+    }
+
+    @Override
+    protected Queue createQueue(String queueName) {
+        try {
+            return (Queue) lookup(queueName);
+        } catch (NamingException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private Object lookup(String name) throws NamingException {
+        if (name.isEmpty()) {
+            throw new RuntimeException("Name to lookup in naming.Context cannot be empty");
+        }
+        return context.lookup(name);
+    }
+
+    @Override
+    protected Topic createTopic(String topicName) {
+        try {
+            return (Topic) lookup(topicName);
+        } catch (NamingException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/jakartalib/src/main/java/com/redhat/mqe/lib/Main.java
+++ b/jakartalib/src/main/java/com/redhat/mqe/lib/Main.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2017 Red Hat, Inc.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.redhat.mqe.lib;
+
+public class Main {
+    public static void main(String[] args, Client clientFactory) throws Exception {
+        CoreClient client = null;
+        if (args.length > 0) {
+            switch (args[0]) {
+                case "sender":
+                    client = clientFactory.makeSenderClient();
+                    break;
+                case "receiver":
+                    client = clientFactory.makeReceiverClient();
+                    break;
+                case "connector":
+                    client = clientFactory.makeConnectorClient();
+                    break;
+            }
+        }
+
+        if (client == null) {
+            printHelpAndExit();
+        } else {
+            // https://stackoverflow.com/questions/2198928/better-handling-of-thread-context-classloader-in-osgi
+            ClassLoader originalClassLoader = Thread.currentThread().getContextClassLoader();
+            try {
+                Thread.currentThread().setContextClassLoader(Main.class.getClassLoader());
+                client.startClient();
+            } finally {
+                Thread.currentThread().setContextClassLoader(originalClassLoader);
+            }
+        }
+    }
+
+    private static void printHelpAndExit() {
+        System.out.println("first argument must be sender, receiver OR connector");
+        System.exit(1);
+    }
+}

--- a/jakartalib/src/main/java/com/redhat/mqe/lib/MessageBrowser.java
+++ b/jakartalib/src/main/java/com/redhat/mqe/lib/MessageBrowser.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2017 Red Hat, Inc.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.redhat.mqe.lib;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+import jakarta.jms.*;
+import java.util.Enumeration;
+
+/**
+ * Class for browsing Queue(s) of messages.
+ */
+public class MessageBrowser extends CoreClient {
+
+    private boolean transacted;
+    private String msgSelector;
+    ClientOptions clientOptions;
+
+    @Inject
+    public MessageBrowser(@Named("Receiver") ClientOptions clientOptions, ConnectionManagerFactory connectionManagerFactory, JmsMessageFormatter jmsMessageFormatter) {
+        this.connectionManagerFactory = connectionManagerFactory;
+        this.jmsMessageFormatter = jmsMessageFormatter;
+        this.clientOptions = clientOptions;
+    }
+
+    @Override
+    ClientOptions getClientOptions() {
+        return this.clientOptions;
+    }
+
+    void setMessageBrowser(ClientOptions options) {
+        if (options != null) {
+            transacted = Boolean.parseBoolean(options.getOption(ClientOptions.TRANSACTED).getValue());
+            if (options.getOption(ClientOptions.MSG_SELECTOR).hasParsedValue()) {
+                msgSelector = options.getOption(ClientOptions.MSG_SELECTOR).getValue();
+            }
+        }
+    }
+
+    @Override
+    public void startClient() {
+        this.setMessageBrowser(clientOptions);
+        try {
+            this.browseMessages();
+        } catch (Exception e) {
+            throw new MessagingException("unable to browse messages", e);
+        }
+    }
+
+    /**
+     * Browse messages using Queue Browser.
+     * By default, you browse all actual messages in the queue.
+     * Messages may be arriving and expiring while the scan is done.
+     */
+    void browseMessages() throws Exception {
+        Connection conn = createConnection(clientOptions);
+        try {
+            Session ssn = createSession(clientOptions, conn, transacted);
+            QueueBrowser qBrowser = ssn.createBrowser((Queue) getDestination(), msgSelector);
+            conn.start();
+            Enumeration<?> enumMsgs = qBrowser.getEnumeration();
+            while (enumMsgs.hasMoreElements()) {
+                Message msg = (Message) enumMsgs.nextElement();
+                printMessage(clientOptions, msg);
+            }
+        } finally {
+            close(conn);
+        }
+    }
+}

--- a/jakartalib/src/main/java/com/redhat/mqe/lib/MessageListenerImpl.java
+++ b/jakartalib/src/main/java/com/redhat/mqe/lib/MessageListenerImpl.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2017 Red Hat, Inc.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.redhat.mqe.lib;
+
+import jakarta.jms.Message;
+import jakarta.jms.MessageListener;
+
+public class MessageListenerImpl implements MessageListener {
+
+    private ReceiverClient rcvrClient;
+
+    MessageListenerImpl(ReceiverClient rcvrClient) {
+        this.rcvrClient = rcvrClient;
+    }
+
+    @Override
+    public synchronized void onMessage(Message msg) {
+        rcvrClient.printMessage(rcvrClient.getClientOptions(), msg);
+    }
+}

--- a/jakartalib/src/main/java/com/redhat/mqe/lib/MessagingExceptionListener.java
+++ b/jakartalib/src/main/java/com/redhat/mqe/lib/MessagingExceptionListener.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2018 Red Hat, Inc.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.redhat.mqe.lib;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import jakarta.jms.ExceptionListener;
+import jakarta.jms.JMSException;
+
+/**
+ * MessagingExceptionListener is created for each connection made.
+ */
+public class MessagingExceptionListener implements ExceptionListener {
+    private Logger LOG = LoggerFactory.getLogger(ConnectionManager.class.getName());
+
+    @Override
+    public void onException(JMSException e) {
+        LOG.error("ExceptionListener error detected! \n{}\n{}", e.getMessage(), e.getCause());
+        e.printStackTrace();
+    }
+}

--- a/jakartalib/src/main/java/com/redhat/mqe/lib/OpenwireJmsMessageFormatter.java
+++ b/jakartalib/src/main/java/com/redhat/mqe/lib/OpenwireJmsMessageFormatter.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2017 Red Hat, Inc.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.redhat.mqe.lib;
+
+import jakarta.jms.JMSException;
+import jakarta.jms.Message;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Message output formatter to python dict,
+ * map, or any other object printable format.
+ * Reusable from old client
+ */
+public class OpenwireJmsMessageFormatter extends JmsMessageFormatter {
+    /**
+     * Openwire -> AMQP mapping http://activemq.apache.org/amqp.html
+     */
+    @Override
+    public Map<String, Object> formatMessage(Message msg, boolean hashContent) throws JMSException {
+        Map<String, Object> result = new HashMap<>();
+        addFormatJMS11(msg, result, hashContent);
+        return result;
+    }
+}

--- a/jakartalib/src/main/java/com/redhat/mqe/lib/Option.java
+++ b/jakartalib/src/main/java/com/redhat/mqe/lib/Option.java
@@ -1,0 +1,219 @@
+/*
+ * Copyright (c) 2017 Red Hat, Inc.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.redhat.mqe.lib;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Class representing one option for client.
+ * Option has it's name, default value, short (optional) and long option argument,
+ * parsed value, whether it has argument or not, etc..
+ */
+public class Option {
+    private String name;
+    private String defaultValue;
+    private String longOptionName;
+    private String shortOptionName;
+    private String argumentExample;
+    private String description;
+    private boolean isCliArgument = true;
+    private boolean hasArgument = false;
+    private String parsedValue = null;
+    private List<String> parsedValuesList;
+    private static String pattern = "-?\\d+(.\\d+)?";
+
+    /**
+     * Special case, for broker host, port, client username, password
+     * credentials (masked as broker_url parameter), protocol and other parameters,
+     * which are not passed as arguments from command line input for client.
+     *
+     * @param name         of the option
+     * @param defaultValue of the option
+     */
+    public Option(String name, String defaultValue) {
+        this(name, null, null, defaultValue, null);
+        isCliArgument = false;
+    }
+
+    /**
+     * Long option constructor.
+     *
+     * @param longOptionName  long option string (Mandatory option)
+     * @param shortOptionName short option string
+     * @param argumentExample depicts the variable for option used in help
+     * @param defaultValue    default value (if possible)
+     * @param description     of this option
+     */
+    public Option(String longOptionName, String shortOptionName, String argumentExample, String defaultValue, String description) {
+        this.name = longOptionName;
+        if (longOptionName == null || longOptionName.equals("")) {
+            throw new IllegalArgumentException("Long option can not be empty");
+        }
+        this.longOptionName = longOptionName;
+        this.shortOptionName = shortOptionName;
+        this.argumentExample = argumentExample;
+        this.defaultValue = defaultValue;
+        this.description = description;
+        if (argumentExample != null && !argumentExample.equals("")) {
+            this.hasArgument = true;
+        }
+
+        if (defaultValue.matches(pattern)) {
+            ClientOptions.addNumericArgumentValueOptionList(this);
+        }
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getDefaultValue() {
+        return defaultValue;
+    }
+
+    /**
+     * Method returns the value which will be used by connection.
+     * Either the default one, or overridden by user input.
+     *
+     * @return String option value to be used for this option. In some
+     * cases it can return null, when option has multipleOptions as List.
+     * In that case, get values using @method getParsedValuesList().
+     */
+    public String getValue() {
+        if (hasParsedValue()) {
+            if (ClientOptions.argsAcceptingMultipleValues.contains(name)) {
+                return null;
+            } else {
+                return parsedValue;
+            }
+        }
+        return defaultValue;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public String getLongOptionName() {
+        return longOptionName;
+    }
+
+    public String getShortOptionName() {
+        return shortOptionName;
+    }
+
+    public String getArgumentExample() {
+        return argumentExample;
+    }
+
+    public boolean hasArgument() {
+        return hasArgument;
+    }
+
+    /**
+     * The method sets the user input value to the Option.
+     * If argument accepts multiple values, set it as parsedValuesList
+     * and parsedValue is null. Otherwise set content as parsedValue.
+     *
+     * @param parsedValue parsed user input for argument value
+     */
+    @SuppressWarnings("unchecked")
+    public void setParsedValue(Object parsedValue) {
+        if (parsedValue == null) {
+            ClientOptions.LOG.error("Null parsed value! Error while creating Option.parsedValue!");
+            System.exit(2);
+        }
+        // is complex type? list of args
+        if (ClientOptions.argsAcceptingMultipleValues.contains(name)) {
+            this.parsedValuesList = new ArrayList<>();
+            if (parsedValue.equals("''") || parsedValue.equals("\"\"") || parsedValue.equals("")) {
+                // send empty message
+                parsedValuesList.add("");
+            } else {
+                for (String item : (List<String>) parsedValue) {
+                    parsedValuesList.add(Utils.removeQuotes(item));
+                }
+                this.parsedValue = null;
+            }
+        } else {
+            // check if the argument value is number
+            if (ClientOptions.numericArgumentValueOptionList.contains(this) && !((String) parsedValue).matches(pattern)) {
+                throw new IllegalArgumentException("Argument " + name + " has not a numeric value! Found:" + parsedValue);
+            }
+            this.parsedValue = Utils.removeQuotes((String) parsedValue);
+        }
+    }
+
+    public boolean hasParsedValue() {
+        return (this.parsedValue != null || this.parsedValuesList != null);
+    }
+
+    public List<String> getParsedValuesList() {
+        return parsedValuesList;
+    }
+
+    public boolean isCliArgument() {
+        return isCliArgument;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        Option option = (Option) o;
+        if (description != null ? !description.equals(option.description) : option.description != null) return false;
+        if (longOptionName != null ? !longOptionName.equals(option.longOptionName) : option.longOptionName != null)
+            return false;
+        if (name != null ? !name.equals(option.name) : option.name != null) return false;
+        if (shortOptionName != null ? !shortOptionName.equals(option.shortOptionName) : option.shortOptionName != null)
+            return false;
+        if (defaultValue != null ? !defaultValue.equals(option.defaultValue) : option.defaultValue != null)
+            return false;
+
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = name != null ? name.hashCode() : 0;
+        result = 31 * result + (defaultValue != null ? defaultValue.hashCode() : 0);
+        result = 31 * result + (longOptionName != null ? longOptionName.hashCode() : 0);
+        result = 31 * result + (shortOptionName != null ? shortOptionName.hashCode() : 0);
+        result = 31 * result + (description != null ? description.hashCode() : 0);
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "Option{" +
+            "name='" + name + '\'' +
+            ", defaultValue='" + defaultValue + '\'' +
+            ", longOptionName='" + longOptionName + '\'' +
+            ", shortOptionName='" + shortOptionName + '\'' +
+            ", argumentExample='" + argumentExample + '\'' +
+            ", description='" + description + '\'' +
+            ", isCliArgument=" + isCliArgument +
+            ", hasArgument=" + hasArgument +
+            ", parsedValue='" + parsedValue + '\'' +
+            "}\n";
+    }
+}

--- a/jakartalib/src/main/java/com/redhat/mqe/lib/ReceiverClient.java
+++ b/jakartalib/src/main/java/com/redhat/mqe/lib/ReceiverClient.java
@@ -1,0 +1,303 @@
+/*
+ * Copyright (c) 2017 Red Hat, Inc.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.redhat.mqe.lib;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+import jakarta.jms.*;
+import java.util.UUID;
+
+import static com.redhat.mqe.lib.ClientOptions.*;
+
+/**
+ * Class for receiving, consuming and interpreting messages.
+ */
+public class ReceiverClient extends CoreClient {
+
+    public static final String SLEEP_AFTER = "after-receive";
+    public static final String SLEEP_AFTER_ACTION = "after-receive-action"; // TODO not implemented
+    public static final String SLEEP_AFTER_TX_ACTION = "after-receive-action-tx-action";
+    public static final String SLEEP_BEFORE = "before-receive";
+
+    private boolean msgListener;
+    private boolean durableSubscriber;
+    private String durableSubscriberPrefix = null;
+    private boolean unsubscribe = false;
+    private String durableSubscriberName = null; // passed from user
+
+    /**
+     * If false, the client(s) consume(s) own message(s). The behavior is undefined for Queue(s).
+     */
+    private boolean noLocal; // TODO implement in future
+    private boolean transacted;
+
+    private int msgCount;
+
+    /**
+     * Session.SESSION_TRANSACTED = 0, Session.AUTO_ACKNOWLEDGE = 1, Session.CLIENT_ACKNOWLEDGE = 2,
+     * Session.DUPS_OK_ACKNOWLEDGE = 3. The last three are non-transactional.
+     */
+    private int txSize;
+    private String txEndloopAction;
+    private double closeSleep;
+    private float duration;
+    private long timeout; // milliseconds, needs to be greater than 0
+    private String durationMode;
+    private boolean processReplyTo;
+
+    /**
+     * Selects messages based on the SQL92 syntax subset. Invalid selector causes the client to fail. Example:
+     * "JMSXDeliveryCount is not null"
+     */
+    private String msgSelector;
+    private String txAction;
+
+    protected ClientOptions rcvrOpts;
+    private String writeBinaryMessageFile;
+    private String writeMessageContentFile;
+
+    @Inject
+    protected MessageBrowser messageBrowser;
+
+    @Inject
+    public ReceiverClient(ConnectionManagerFactory connectionManagerFactory, JmsMessageFormatter jmsMessageFormatter, @Named("Receiver") ClientOptions options) {
+        this.connectionManagerFactory = connectionManagerFactory;
+        this.jmsMessageFormatter = jmsMessageFormatter;
+        this.rcvrOpts = options;
+        setGlobalClientOptions(rcvrOpts);
+        String destinationType = rcvrOpts.getOption(DESTINATION_TYPE).getValue();
+        LOG.debug("Using destination type:" + destinationType);
+    }
+
+    public ReceiverClient() {
+
+    }
+
+    @Override
+    public ClientOptions getClientOptions() {
+        return rcvrOpts;
+    }
+
+    protected void setReceiverClient(ClientOptions options) {
+        // TODO add support for noLocal to ClientOptions
+        if (options != null) {
+            msgCount = Integer.parseInt(options.getOption(COUNT).getValue()) > 0 ? Integer.parseInt(options.getOption(COUNT).getValue()) : 0;
+            msgListener = Boolean.parseBoolean(options.getOption(MSG_LISTENER).getValue());
+            durableSubscriber = Boolean.parseBoolean(options.getOption(DURABLE_SUBSCRIBER).getValue());
+            durableSubscriberPrefix = options.getOption(DURABLE_SUBSCRIBER_PREFIX).getValue();
+            unsubscribe = Boolean.parseBoolean(options.getOption(UNSUBSCRIBE).getValue());
+            durableSubscriberName = options.getOption(DURABLE_SUBSCRIBER_NAME).getValue();
+//      durableConsumer = Boolean.parseBoolean(options.getOption(DURABLE_CONSUMER).getValue()); JMS 2.0
+            msgSelector = options.getOption(MSG_SELECTOR).getValue();
+
+            closeSleep = Double.parseDouble(options.getOption(CLOSE_SLEEP).getValue());
+            closeSleep *= 1000;
+            duration = Float.parseFloat(options.getOption(DURATION).getValue());
+            duration *= 1000;
+            durationMode = options.getOption(ClientOptions.DURATION_MODE).getValue().toLowerCase();
+
+            timeout = Long.parseLong(options.getOption(TIMEOUT).getValue());
+            if (timeout > 0) timeout *= 1000;
+
+            transacted = Boolean.parseBoolean(options.getOption(TRANSACTED).getValue());
+            txAction = options.getOption(TX_ACTION).getValue();
+            txSize = Integer.parseInt(options.getOption(TX_SIZE).getValue());
+            txEndloopAction = options.getOption(TX_ENDLOOP_ACTION).getValue();
+            processReplyTo = Boolean.parseBoolean(options.getOption(PROCESS_REPLY_TO).getValue());
+            writeBinaryMessageFile = options.getOption(MSG_BINARY_CONTENT_TO_FILE).getValue();
+            writeMessageContentFile = options.getOption(MSG_CONTENT_TO_FILE).getValue();
+        }
+    }
+
+    boolean isAsync() {
+        return this.msgListener;
+    }
+
+    @Override
+    public void startClient() {
+        // Browse if given the option
+        if (this.rcvrOpts.getOption(ReceiverOptions.BROWSER).hasParsedValue()) {
+            messageBrowser.startClient();
+            return;
+        }
+
+        this.setReceiverClient(rcvrOpts);
+
+        // Unsubscribe given durable topic subscriber
+        if (unsubscribe && durableSubscriberName != null) {
+            this.unsubscribe();
+            return;
+        }
+
+        this.consumeMessage();
+    }
+
+    private void unsubscribe() {
+        Connection connection = createConnection(rcvrOpts);
+        Session session = createSession(rcvrOpts, connection, transacted);
+        try {
+            session.unsubscribe(durableSubscriberName);
+        } catch (JMSException e) {
+            LOG.error("Error while unsubscribing durable subscriptor " + durableSubscriberName);
+            e.printStackTrace();
+        } finally {
+            close(session);
+            close(connection);
+        }
+    }
+
+    /**
+     * This method contains logic for consuming messages: - creates Connection - creates Session (transacted vs
+     * non-transacted) - creates MessageConsumer with Destination (topic vs Queue), message selector and support for local
+     * vs non-local transactions - supports synchronous vs asynchronous (message listener) mode - supports transactions
+     */
+    void consumeMessage() {
+        Connection conn = createConnection(rcvrOpts);
+        Session ssn = createSession(rcvrOpts, conn, transacted);
+        try {
+            MessageConsumer msgConsumer;
+            if (durableSubscriber && getDestinationType().equals(ConnectionManager.TOPIC_OBJECT)) {
+                createSubscriptionName(durableSubscriberPrefix);
+                msgConsumer = ssn.createDurableSubscriber((Topic) getDestination(), durableSubscriberName, msgSelector, noLocal);
+            } else {
+                msgConsumer = ssn.createConsumer(getDestination(), msgSelector, noLocal);
+            }
+            MessageListener msgLsnr = new MessageListenerImpl(this);
+
+            if (msgListener) {
+                msgConsumer.setMessageListener(msgLsnr);
+            }
+
+            conn.start();
+
+            //===  ASYNC ===
+            while (msgListener) {
+                Utils.sleep((int) duration);
+            }
+
+            //=== SYNC ===
+            int i = 0;
+            Message msg;
+
+            double initialTimestamp = Utils.getTime();
+            do {
+                if (durationMode.equals(SLEEP_BEFORE)) {
+                    LOG.trace("Sleeping before receive");
+                    Utils.sleepUntilNextIteration(initialTimestamp, msgCount, duration, i + 1);
+                }
+
+                if (timeout == 0) {
+                    // TODO JMS SPEC BUG https://java.net/jira/browse/JMS_SPEC-85
+                    // msg = msgConsumer.receiveNoWait();
+                    msg = msgConsumer.receive(200); // the lowest number of ms to receive a message was 36ms
+                } else if (timeout == -1) {
+                    msg = msgConsumer.receive(); // == msgConsumer.receive(0)
+                } else {
+                    msg = msgConsumer.receive(timeout);
+                }
+
+                if (durationMode.equals(SLEEP_AFTER)) {
+                    LOG.trace("Sleeping after receive");
+                    Utils.sleepUntilNextIteration(initialTimestamp, msgCount, duration, i + 1);
+                }
+
+                if (ssn.getAcknowledgeMode() == Session.CLIENT_ACKNOWLEDGE && msg != null) {
+                    msg.acknowledge();
+                }
+
+                if (msg != null) {
+                    String file = null;
+                    if (!writeBinaryMessageFile.isEmpty()) {
+                        file = writeBinaryMessageFile;
+                    }
+                    if (!writeMessageContentFile.isEmpty()) {
+                        file = writeMessageContentFile;
+                    }
+                    if (file != null) {
+                        if (Boolean.valueOf(rcvrOpts.getOption(ClientOptions.MSG_CONTENT_STREAM).getValue())) {
+                            JmsUtils.streamMessageContentToFile(file, msg, i);
+                        } else {
+                            JmsUtils.writeMessageContentToFile(file, msg, i);
+                        }
+                    }
+                    i++;
+                    printMessage(rcvrOpts, msg);
+                } else {
+                    LOG.trace("Did not receive any message!");
+                }
+
+                //=== TRANSACTION ===
+                if (ssn.getTransacted() && txSize != 0) {
+                    if (i % txSize == 0) {
+                        doTransaction(ssn, txAction);
+
+                        if (durationMode.equals(SLEEP_AFTER_TX_ACTION)) {
+                            LOG.trace("Sleeping after transaction");
+                            Utils.sleepUntilNextIteration(initialTimestamp, msgCount, duration, i + 1);
+                        }
+                    }
+                }
+
+                //=== REPLY TO ===
+                if (processReplyTo && msg != null && msg.getJMSReplyTo() != null) {
+                    MessageProducer msgProducer = ssn.createProducer(msg.getJMSReplyTo());
+                    msg.setJMSReplyTo(null);
+                    msgProducer.send(msg);
+                    close(msgProducer);
+                }
+
+                if (i == msgCount) {
+                    close(msgConsumer);
+                    break; // or timeout
+                }
+            } while (msg != null);
+
+            if (ssn.getTransacted()) {
+                LOG.trace("Performing tx-endloop-action " + txEndloopAction);
+                doTransaction(ssn, txEndloopAction);
+            }
+        } catch (InvalidSelectorException se) {
+            LOG.error("Invalid selector \"{}\" has been specified.", msgSelector);
+            se.printStackTrace();
+            System.exit(2);
+        } catch (JMSException jmse) {
+            LOG.error("Exception while consuming message!");
+            jmse.printStackTrace();
+            System.exit(1);
+        } finally {
+            if (closeSleep > 0) {
+                Utils.sleep((int) closeSleep);
+            }
+            close(ssn);
+            close(conn);
+        }
+    }
+
+    private void createSubscriptionName(String customPrefix) {
+        if (durableSubscriberName == null) {
+            UUID uuid = UUID.randomUUID();
+            if (customPrefix == null || customPrefix.equals(""))
+                durableSubscriberName = "qpid-jms-" + uuid.toString();
+            else
+                durableSubscriberName = customPrefix + uuid.toString();
+        }
+        LOG.debug("DurableSubscriptionName=" + durableSubscriberName);
+    }
+}

--- a/jakartalib/src/main/java/com/redhat/mqe/lib/ReceiverOptions.java
+++ b/jakartalib/src/main/java/com/redhat/mqe/lib/ReceiverOptions.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright (c) 2017 Red Hat, Inc.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.redhat.mqe.lib;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.inject.Inject;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Default options for ReceiverClient.
+ * Constructed from CommonOptions and receiverDefaultOptions.
+ */
+public class ReceiverOptions extends ClientOptions {
+    private List<Option> options = null;
+    private Logger LOG = LoggerFactory.getLogger(ReceiverOptions.class);
+    private final List<Option> receiverDefaultOptions = new ArrayList<Option>();
+
+    {
+        receiverDefaultOptions.addAll(Arrays.asList(
+            // 
+            new Option(ADDRESS, "a", "ADDRESS", "", "Queue/Topic destination"),
+            new Option(TIMEOUT, "t", "TIMEOUT", "0", "timeout in seconds to wait before exiting"),
+            new Option("forever", "f", "", "false", "DEPRECATED! use \"timeout -1\" ignore timeout and wait forever"),
+            new Option(ACTION, "", "ACTION", "acknowledge", "action on acquired message (default ack)"),
+            new Option(COUNT, "c", "MESSAGES", "0", "read c messages, then exit (default 0 for all messages)"),
+            new Option(DURATION, "d", "DURATION", "0", "message actions total duration in seconds (defines msg-rate together with count)"),
+            new Option(LOG_MSGS, "", "LOGMSGFMT", "upstream", "message[s] reporting style (dict|body|upstream|none)"),
+            new Option(LOG_STATS, "", "LEVEL", "upstream", "report various statistic/debug information"),
+            new Option(OUT, "", "FORMAT", "repr", "message[s] reporting format (repr|json)"),
+            new Option(TX_SIZE, "", "TXBSIZE", "0", "transactional mode: batch message count size (negative skips tx-action before exit)"),
+            new Option(TX_ACTION, "", "TXACTION", "commit", "transactional action at the end of tx batch"),
+            new Option(TX_ENDLOOP_ACTION, "", "TXACTION", "None", "transactional action after sending all messages in loop (commit|rollback|recover|None)"),
+            new Option(DURATION_MODE, "", "VALUE", ReceiverClient.SLEEP_AFTER, "specifies where to wait (" + ReceiverClient.SLEEP_BEFORE
+                + "/" + ReceiverClient.SLEEP_AFTER + "/" + ReceiverClient.SLEEP_AFTER_ACTION + "/" + ReceiverClient.SLEEP_AFTER_TX_ACTION + ")"),
+            new Option(SYNC_MODE, "", "SYNCMODE", "action", "synchronization mode: none/session/action/persistent/transient"),
+            new Option(MSG_LISTENER, "", "ENABLED", "false", "receive messages using a MessageListener"),
+            new Option(DURABLE_SUBSCRIBER, "", "ENABLED", "false", "create durable subscription to topic"),
+            new Option(UNSUBSCRIBE, "", "UNSUBSCRIBE", "false", "unsubscribe durable subscriptor with given name (provide " + DURABLE_SUBSCRIBER_NAME + ")"),
+            new Option(DURABLE_SUBSCRIBER_PREFIX, "", "PREFIX", "", "prefix to use to identify this connection subscriber"),
+            new Option(DURABLE_SUBSCRIBER_NAME, "", "PREFIX", "", "name of the durable subscriber to be unsubscribe"),
+//        new Option(DURABLE_CONSUMER, "", "ENABLED", "false", "create durable consumer from topic"), JMS 2.0
+            new Option(MSG_SELECTOR, "", "SELECT", "", "select messages based on the SQL92 subset"),
+            new Option("verbose", "", "", "false", "DEPRECATED? verbose AMQP message output"),
+            new Option(CAPACITY, "", "CAPACITY", "-1", "sender|receiver capacity (no effect in jms atm)"),
+            new Option(BROWSER, "", "ENABLED", "false", "if true, browse messages instead of reading"),
+            new Option(PROCESS_REPLY_TO, "", null, "", "whether to process reply to (true) or ignore it"),
+            new Option(MSG_BINARY_CONTENT_TO_FILE, "", "FILEPATH", "", "write binary data to provided file with prefix"),
+            new Option(MSG_CONTENT_TO_FILE, "", "FILEPATH", "", "write message content to provided file with prefix")
+        ));
+//    receiverDefaultOptions.put("forever", "false"); // drain only option
+//    receiverDefaultOptions.put("action", "acknowledge"); // acknowledge, reject, release, noack
+
+    }
+
+    @Inject
+    public ReceiverOptions() {
+        this.options = ClientOptionManager.mergeOptionLists(super.getDefaultOptions(), receiverDefaultOptions);
+        /**
+         -h, --help                                            show this help message and exit
+         -b USER/PASS@HOST:PORT, --broker USER/PASS@HOST:PORT  connect to specified broker (default guest/guest@localhost:5672)
+         -t TIMEOUT, --timeout TIMEOUT                         timeout in seconds to wait before exiting (default 0)
+         -f, --forever                                         ignore timeout and wait forever
+         -c COUNT, --count COUNT                               read c messages, then exit (default 0)
+         --duration DURATION                                   message actions total duration (defines msg-rate together with count) (default 0)
+         --con-option NAME=VALUE                               JMS Connection URL options. Ex sync_ack=true sync_publish=all
+         --broker-option NAME=VALUE                            JMS Broker URL options. Ex ssl=true sasl_mechs=GSSAPI
+         --connection-options {NAME=VALUE,NAME=VALUE..}        QPID Connection URL options. (c++ style)
+         --accept ACTION                                       action on acquired message (default ack)
+         -log-msgs LOGMSGFMT                                  message[s] reporting style (dict|body|upstream|none) (default upstream)
+         * --log-stats LEVEL                                     report various statistic/debug information (default )
+         --tx-batch-size TXBSIZE                               transactional mode: batch message count size (negative skips tx-action before exit) (default 0)
+         --tx-action TXACTION                                  transactional action at the end of tx batch (default commit)
+         --sync-mode SMODE                                     synchronization mode: none/session/action/persistent/transient (default action)
+         --msg-listener-ena                                    receive messages using a MessageListener
+         --verbose                                             verbose AMQP message output
+         --capacity CPCT                                       sender|receiver capacity (no effect in jms atm) (default -1)
+         --close-sleep CSLEEP                                  sleep before publisher/subscriber/session/connection.close() (default 0)
+         TODO *
+         */
+    }
+
+    @Override
+    public Option getOption(String name) {
+        if (name != null) {
+            for (Option option : options) {
+                if (name.equals(option.getName()))
+                    return option;
+            }
+        } else {
+            LOG.error("Accessing client options map with null key.");
+            throw new IllegalArgumentException("Null name is not allowed!");
+        }
+        return null;
+    }
+
+    @Override
+    public List<Option> getClientDefaultOptions() {
+        return receiverDefaultOptions;
+    }
+
+    @Override
+    public List<Option> getClientOptions() {
+        return options;
+    }
+
+    @Override
+    public String toString() {
+        return "ReceiverOptions{" +
+            "options=" + options;
+    }
+
+}

--- a/jakartalib/src/main/java/com/redhat/mqe/lib/SenderClient.java
+++ b/jakartalib/src/main/java/com/redhat/mqe/lib/SenderClient.java
@@ -1,0 +1,222 @@
+/*
+ * Copyright (c) 2017 Red Hat, Inc.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.redhat.mqe.lib;
+
+import com.redhat.mqe.lib.message.MessageProvider;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+import jakarta.jms.*;
+import java.util.List;
+
+/**
+ * SenderClient is able to send various messages with wide options
+ * of settings of these messages.
+ */
+public class SenderClient extends CoreClient {
+    protected ClientOptions senderOptions;
+    protected List<Content> content;
+    static final String AMQ_SUBJECT = "JMS_AMQP_Subject";
+    static final String AMQ_USERID = "JMSXUserID";
+    public static final String BEFORE_SEND = "before-send";
+    public static final String AFTER_SEND = "after-send";
+    public static final String AFTER_SEND_TX_ACTION = "after-send-tx-action";
+
+
+    @Inject
+    public SenderClient(ConnectionManagerFactory connectionManagerFactory, JmsMessageFormatter jmsMessageFormatter, @Named("Sender") ClientOptions options) {
+        this.connectionManagerFactory = connectionManagerFactory;
+        this.jmsMessageFormatter = jmsMessageFormatter;
+        this.senderOptions = options;
+    }
+
+    public SenderClient() {
+
+    }
+
+    /**
+     * Initial method to start the client.
+     * Initialization of content, properties and everything about
+     * how to send message is done/initiated by this method.
+     * Contains the main sending loop method.
+     */
+    public void startClient() {
+        ClientOptions senderOptions = this.getClientOptions();
+        setGlobalClientOptions(senderOptions);
+        Connection connection = this.createConnection(senderOptions);
+
+        // Transactions support
+        int transactionSize = 0;
+        String transaction = null;
+        if (senderOptions.getOption(ClientOptions.TX_SIZE).hasParsedValue()
+            || senderOptions.getOption(ClientOptions.TX_ENDLOOP_ACTION).hasParsedValue()) {
+            transactionSize = Integer.parseInt(senderOptions.getOption(ClientOptions.TX_SIZE).getValue());
+            if (senderOptions.getOption(ClientOptions.TX_ACTION).hasParsedValue()) {
+                transaction = senderOptions.getOption(ClientOptions.TX_ACTION).getValue().toLowerCase();
+            } else {
+                transaction = senderOptions.getOption(ClientOptions.TX_ENDLOOP_ACTION).getValue().toLowerCase();
+            }
+        }
+
+        try {
+            Session session = (transaction == null || transaction.equals("none")) ?
+                this.createSession(senderOptions, connection, false) : this.createSession(senderOptions, connection, true);
+            connection.start();
+            MessageProducer msgProducer = session.createProducer(this.getDestination());
+            setMessageProducer(senderOptions, msgProducer);
+
+            // Calculate msg-rate from COUNT & DURATION
+            double initialTimestamp = Utils.getTime();
+            int count = Integer.parseInt(senderOptions.getOption(ClientOptions.COUNT).getValue());
+            double duration = Double.parseDouble(senderOptions.getOption(ClientOptions.DURATION).getValue());
+            duration *= 1000;  // convert to milliseconds
+
+            final MessageProvider messageProvider = new MessageProvider(senderOptions, session).newInstance();
+
+            int msgCounter = 0;
+            String durationMode = senderOptions.getOption(ClientOptions.DURATION_MODE).getValue();
+            while (true) {
+                // Create message and fill body with data (content)
+                Message message = messageProvider.provideMessage(msgCounter);
+
+                // sleep for given amount of time, defined by msg-rate "before-send"
+                if (durationMode.equals(BEFORE_SEND)) {
+                    LOG.trace("Sleeping before send");
+                    Utils.sleepUntilNextIteration(initialTimestamp, count, duration, msgCounter + 1);
+                }
+
+                // Send messages
+                try {
+                    msgProducer.send(message);
+                } catch (Exception e) {
+                    switch (e.getCause().getClass().getName()) {
+                        case "org.apache.qpid.jms.provider.exceptions.ProviderDeliveryReleasedException":
+                            String onRelease = senderOptions.getOption(ClientOptions.ON_RELEASE).getValue();
+                            LOG.trace(String.format("Message released [action: %s]", onRelease));
+                            switch (onRelease) {
+                                case "fail":
+                                    throw e;
+                                case "retry":
+                                    continue;
+                            }
+                        default:
+                            // Preserve original behavior
+                            throw e;
+                    }
+                }
+                msgCounter++;
+                // Makes message body read only from write only mode
+                if (message instanceof StreamMessage) {
+                    ((StreamMessage) message).reset();
+                }
+                if (message instanceof BytesMessage) {
+                    ((BytesMessage) message).reset();
+                }
+                printMessage(senderOptions, message);
+
+                // close streaming message source if that is what we are doing
+                try {
+                    messageProvider.close();
+                } catch (Exception e) {
+                    e.printStackTrace();
+                }
+
+                // sleep for given amount of time, defined by msg-rate "after-send-before-tx-action"
+                if (durationMode.equals(AFTER_SEND)) {
+                    LOG.trace("Sleeping after send");
+                    Utils.sleepUntilNextIteration(initialTimestamp, count, duration, msgCounter + 1);
+                }
+
+                // TX support
+                if (transaction != null && transactionSize != 0) {
+                    if (msgCounter % transactionSize == 0) {
+                        // Do transaction action
+                        doTransaction(session, transaction);
+                    }
+                }
+                // sleep for given amount of time, defined by msg-rate "after-send-after-tx-action"
+                if (durationMode.equals(AFTER_SEND_TX_ACTION)) {
+                    LOG.trace("Sleeping after send & tx action");
+                    Utils.sleepUntilNextIteration(initialTimestamp, count, duration, msgCounter + 1);
+                }
+                if (count == 0) continue;
+                if (msgCounter == count) break;
+            }
+
+            // Finish transaction with sending of the rest messages
+            if (transaction != null) {
+                doTransaction(session, senderOptions.getOption(ClientOptions.TX_ENDLOOP_ACTION).getValue());
+            }
+        } catch (JMSException | IllegalArgumentException jmse) {
+            LOG.error("Error while sending a message!", jmse.getMessage());
+            jmse.printStackTrace();
+            System.exit(1);
+        } finally {
+            double closeSleep = Double.parseDouble(this.getClientOptions().getOption(ClientOptions.CLOSE_SLEEP).getValue());
+            closeConnObjects(this, closeSleep);
+            this.close(connection);
+        }
+    }
+
+    /**
+     * Set default priority, ttl, durability and creating of id,
+     * timestamps for messages of this message producer.
+     *
+     * @param senderOptions specify defined options for messages & messageProducers
+     * @param producer      set this message producer
+     */
+    protected static void setMessageProducer(ClientOptions senderOptions, MessageProducer producer) {
+        try {
+            // set delivery mode - durable/non-durable
+            String deliveryModeArg = senderOptions.getOption(ClientOptions.MSG_DURABLE).getValue().toLowerCase();
+            int deliveryMode = (deliveryModeArg.equals("true") || deliveryModeArg.equals("yes"))
+                ? DeliveryMode.PERSISTENT : DeliveryMode.NON_PERSISTENT;
+            producer.setDeliveryMode(deliveryMode);
+            // set time to live of message if provided
+            if (senderOptions.getOption(ClientOptions.MSG_TTL).hasParsedValue()) {
+                producer.setTimeToLive(Long.parseLong(senderOptions.getOption(ClientOptions.MSG_TTL).getValue()));
+            }
+            // set message priority if provided
+            if (senderOptions.getOption(ClientOptions.MSG_PRIORITY).hasParsedValue()) {
+                int priority = Integer.parseInt(senderOptions.getOption(ClientOptions.MSG_PRIORITY).getValue());
+                if (priority < 0 || priority > 10) {
+                    LOG.warn("Message priority is not in JMS interval <0, 10>.");
+                }
+                producer.setPriority(priority);
+            }
+            // Set Message ID or disable it completely
+            if (senderOptions.getOption(ClientOptions.MSG_ID).hasParsedValue()) {
+                if (senderOptions.getOption(ClientOptions.MSG_ID).getValue().equals("noid")) {
+                    producer.setDisableMessageID(true);
+                }
+            }
+            // Producer does not generate timestamps - for performance only
+            producer.setDisableMessageTimestamp(
+                Boolean.parseBoolean(senderOptions.getOption(ClientOptions.MSG_NOTIMESTAMP).getValue()));
+        } catch (JMSException e) {
+            e.printStackTrace();
+        }
+    }
+
+    @Override
+    protected ClientOptions getClientOptions() {
+        return senderOptions;
+    }
+}

--- a/jakartalib/src/main/java/com/redhat/mqe/lib/SenderOptions.java
+++ b/jakartalib/src/main/java/com/redhat/mqe/lib/SenderOptions.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright (c) 2017 Red Hat, Inc.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.redhat.mqe.lib;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.inject.Inject;
+import java.util.Arrays;
+import java.util.LinkedList;
+import java.util.List;
+
+/**
+ * Default options for SenderClient.
+ */
+public class SenderOptions extends ClientOptions {
+
+    private List<Option> options = new LinkedList<Option>();
+    private Logger LOG = LoggerFactory.getLogger(ReceiverOptions.class);
+    private final List<Option> senderDefaultOptions = new LinkedList<Option>();
+
+    {
+        senderDefaultOptions.addAll(Arrays.asList(
+            new Option(ADDRESS, "a", "ADDRESS", "", "Queue/Topic destination"),
+            new Option(TIMEOUT, "t", "TIMEOUT", "0", "timeout in seconds to wait before exiting"),
+            new Option(COUNT, "c", "MESSAGES", "1", "stop after count messages have been sent, zero disables"),
+            new Option(DURATION, "d", "DURATION", "0", "message actions total duration in seconds (defines msg-rate together with count)"),
+            new Option(DURATION_MODE, "", "VALUE", "after-send", "specifies where to wait (before-send/after-send/after-send-tx-action"),
+            new Option(MSG_ID, "i", "MSG_ID", "", "use the supplied id instead of generating one. use \'noid\' to not generate IDs"),
+            new Option(PROPERTY_TYPE, "", "PTYPE", "String", "specify the type of message property"),
+            new Option(MSG_PROPERTY, "", "KEY=PVALUE", "", "specify message property as KEY=VALUE (use '~' instead of '=' for auto-casting)"),
+            new Option(CONTENT_TYPE, "", "CTYPE", "String", "specify type of the actual content type"),
+            new Option(MSG_CONTENT_TYPE, "", "MSGTYPE", "", "type of JMSMessageBody to use in header"),
+            new Option(MSG_CONTENT_FROM_FILE, "", "PATH", "", "specify filename to load content from"),
+            new Option(MSG_CONTENT, "", "CONTENT", "", "actual content fed to message body"),
+            new Option(MSG_CONTENT_BINARY, "", "BIN_CONTENT", "false", "is message content binary"),
+            new Option(MSG_CONTENT_LIST_ITEM, "L", "VALUE", "", "item from list"),
+            new Option(MSG_CONTENT_MAP_ITEM, "M", "KEY=VALUE", "", "Map item specified as KEY=VALUE (use '~' instead of '=' for auto-casting)"),
+            new Option(MSG_NOTIMESTAMP, "", "TIMESTAMP", "false", "producer do not create timestamps for messages"),
+            new Option(MSG_REPLY_TO, "", "QUEUE", "", "reply to provided queue"),
+            new Option(MSG_SUBJECT, "", "SUBJECT", "", "specify message subject"),
+            new Option(MSG_DURABLE, "", "MSG_DURABLE", "yes", "send durable messages: yes/no|true/false"),
+            new Option(LOG_MSGS, "", "LOGMSGFMT", "upstream", "message[s] reporting style (dict|body|upstream|none)"),
+            new Option(LOG_STATS, "", "LEVEL", "upstream", "report various statistic/debug information"),
+            new Option(OUT, "", "FORMAT", "repr", "message[s] reporting format (repr|json)"),
+            new Option(MSG_TTL, "", "TTL", "0", "message time-to-live (ms)"),
+            new Option(MSG_PRIORITY, "", "MSG_PRIORITY", "4", "message priority"),
+            new Option(MSG_CORRELATION_ID, "", "MSGCORRID", "", "message correlation id"),
+            new Option(MSG_USER_ID, "", "USER", "", "message user id"),
+            new Option(MSG_GROUP_ID, "", "GROUPID", "", "message group id - JMSXGroupID"),
+            new Option(MSG_GROUP_SEQ, "", "SEQUENCE", "", "message group sequence - JMSXGroupSeq"),
+            new Option(MSG_REPLY_TO_GROUP_ID, "", "GROUPID", "", "reply to message group id"),
+            new Option(TX_SIZE, "", "TXSIZE", "0", "transactional mode: batch message count size"),
+            new Option(TX_ACTION, "", "TXACTION", "commit", "transactional action at the end of tx batch (commit|rollback|recover|None)"),
+            new Option(TX_ENDLOOP_ACTION, "", "TXACTION", "None", "transactional action after sending all messages in loop (commit|rollback|recover|None)"),
+            // TODO
+            new Option(SYNC_MODE, "", "SYNCMODE", "action", "synchronization mode: none/session/action/persistent/transient"),
+            new Option(CAPACITY, "", "CAPACITY", "-1", "sender|receiver capacity (no effect in jms atm)")
+        ));
+    }
+
+    @Inject
+    public SenderOptions() {
+        this.options = ClientOptionManager.mergeOptionLists(super.getDefaultOptions(), senderDefaultOptions);
+    }
+
+    @Override
+    public Option getOption(String name) {
+        if (name != null) {
+            for (Option option : options) {
+                if (name.equals(option.getName()))
+                    return option;
+            }
+        } else {
+            LOG.error("Accessing client options map with null key.");
+            throw new IllegalArgumentException("Null name is not allowed!");
+        }
+        // TODO fix this!?
+        return null;
+    }
+
+    @Override
+    public List<Option> getClientDefaultOptions() {
+        return senderDefaultOptions;
+    }
+
+    public List<Option> getClientOptions() {
+        return options;
+    }
+
+    @Override
+    public String toString() {
+        return "SenderOptions{" +
+            "options=" + options +
+            '}';
+    }
+
+    /**
+     -h, --help                                            show this help message and exit
+     -b USER/PASS@HOST:PORT, --broker USER/PASS@HOST:PORT  connect to specified broker (default guest/guest@localhost:5672)
+     -t TIMEOUT, --timeout TIMEOUT                         timeout in seconds to wait before exiting (default 0)
+     -c COUNT, --count COUNT                               stop after count messages have been sent, zero disables (default 1)
+     -i, --id                                              use the supplied id instead of generating one
+     --duration DURATION                                   message actions total duration (defines msg-rate together with count) (default 0)
+     -P NAME=VALUE, --property NAME=VALUE                  specify message property
+     -M KEY=VALUE, --map KEY=VALUE                         specify entry for map content
+     --content TEXT                                        specify textual content
+     --content-from-file TEXT                              specify filename to load content from
+     --con-option NAME=VALUE                               JMS Connection URL options. Ex sync_ack=true sync_publish=all
+     --broker-option NAME=VALUE                            JMS Broker URL options. Ex ssl=true sasl_mechs=GSSAPI
+     --connection-options {NAME=VALUE,NAME=VALUE..}        QPID Connection URL options. (c++ style)
+     --log-msgs LOGMSGFMT                                  message[s] reporting style (dict|body|upstream|none) (default )
+     --log-stats LEVEL                                     report various statistic/debug information (default )
+     --tx-batch-size TXBSIZE                               transactional mode: batch message count size (negative skips tx-action before exit) (default 0)
+     --tx-action TXACTION                                  transactional action at the end of tx batch (default commit)
+     --sync-mode SMODE                                     synchronization mode: none/session/action/persistent/transient (default action)
+
+     --durable MSG_DURABLE                                     send durable messages: yes/no (default )
+     --ttl TTL                                             message time-to-live (ms) (default 0)
+     --priority MSG_PRIORITY                                   message time-to-live (ms) (default -1)
+     --capacity CPCT                                       sender|receiver capacity (no effect in jms atm) (default -1)
+     --close-sleep CSLEEP                                  sleep before publisher/subscriber/session/connection.close() (default 0)
+     */
+}

--- a/jakartalib/src/main/java/com/redhat/mqe/lib/message/BytesMessageProvider.java
+++ b/jakartalib/src/main/java/com/redhat/mqe/lib/message/BytesMessageProvider.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2018 Red Hat, Inc.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.redhat.mqe.lib.message;
+
+import com.redhat.mqe.lib.ClientOptions;
+
+import jakarta.jms.BytesMessage;
+import jakarta.jms.JMSException;
+import jakarta.jms.Session;
+import java.io.Closeable;
+import java.io.InputStream;
+
+public class BytesMessageProvider extends MessageProvider implements AutoCloseable {
+    private final Session session;
+    /**
+     * most recent message's content, for closing streamed message content
+     */
+    private Object content;
+
+    public BytesMessageProvider(ClientOptions senderOptions, Session session) {
+        super(senderOptions, session);
+        this.session = session;
+    }
+
+    @Override
+    public BytesMessage provideMessage(long msgCounter) throws JMSException {
+        // do not cache instance, would not work for streaming messages
+        return (BytesMessage) createMessage();
+    }
+
+    public BytesMessage createTypedMessage() throws JMSException {
+        BytesMessage bytesMessage = session.createBytesMessage();
+
+        LOG.debug("Filling ByteMessage with binary data");
+        content = messageContent();
+        if (content instanceof byte[]) {
+            bytesMessage.writeBytes((byte[]) content);
+        } else if (content instanceof InputStream) {
+            final String jmsAmqInputStream = "JMS_AMQ_InputStream";
+            bytesMessage.setObjectProperty(jmsAmqInputStream, content);
+        }
+
+        return bytesMessage;
+    }
+
+    @Override
+    public void close() throws Exception {
+        if (content instanceof Closeable) {
+            ((Closeable) content).close();
+        }
+    }
+}

--- a/jakartalib/src/main/java/com/redhat/mqe/lib/message/EmptyMessageProvider.java
+++ b/jakartalib/src/main/java/com/redhat/mqe/lib/message/EmptyMessageProvider.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2018 Red Hat, Inc.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.redhat.mqe.lib.message;
+
+import com.redhat.mqe.lib.ClientOptions;
+
+import jakarta.jms.JMSException;
+import jakarta.jms.Message;
+import jakarta.jms.Session;
+
+public class EmptyMessageProvider extends MessageProvider {
+    private final Session session;
+
+    public EmptyMessageProvider(ClientOptions senderOptions, Session session) {
+        super(senderOptions, session);
+        this.session = session;
+    }
+
+    @Override
+    public Message provideMessage(long msgCounter) throws JMSException {
+        return createMessage();
+    }
+
+    @Override
+    public Message createTypedMessage() throws JMSException {
+        return session.createMessage();
+    }
+}

--- a/jakartalib/src/main/java/com/redhat/mqe/lib/message/MapMessageProvider.java
+++ b/jakartalib/src/main/java/com/redhat/mqe/lib/message/MapMessageProvider.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2018 Red Hat, Inc.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.redhat.mqe.lib.message;
+
+import com.redhat.mqe.lib.ClientOptions;
+import com.redhat.mqe.lib.Content;
+import com.redhat.mqe.lib.MessagingException;
+import com.redhat.mqe.lib.Utils;
+
+import jakarta.jms.JMSException;
+import jakarta.jms.MapMessage;
+import jakarta.jms.Session;
+import java.util.ArrayList;
+import java.util.List;
+
+public class MapMessageProvider extends MessageProvider {
+    private final ClientOptions senderOptions;
+    private final Session session;
+
+    public MapMessageProvider(ClientOptions senderOptions, Session session) {
+        super(senderOptions, session);
+        this.senderOptions = senderOptions;
+        this.session = session;
+    }
+
+    @Override
+    public MapMessage provideMessage(long msgCounter) throws JMSException {
+        return (MapMessage) createMessage();
+    }
+
+    @Override
+    public MapMessage createTypedMessage() throws JMSException {
+        MapMessage mapMessage = session.createMapMessage();
+        fillMapMessage(senderOptions, mapMessage);
+        return mapMessage;
+    }
+
+    /**
+     * Fill MapMessage with a data provided by user input as *content*.
+     *
+     * @param senderOptions sender options
+     * @param mapMessage    message to be filled with data
+     */
+    private void fillMapMessage(ClientOptions senderOptions, MapMessage mapMessage) throws JMSException {
+        LOG.trace("set MSG_CONTENT_MAP_ITEM");
+
+        List<String> values = senderOptions.getOption(ClientOptions.MSG_CONTENT_MAP_ITEM).getParsedValuesList();
+        if (isEmptyMessage(values)) {
+            return;
+        }
+        List<Content> content = new ArrayList<>();
+        for (String parsedItem : values) {
+            content.add(new Content(globalContentType(), parsedItem, true));
+        }
+
+        for (Content c : content) {
+            LOG.trace("Filling MapMessage with: " + c.getValue() + " class=" + c.getType().getName());
+            if (Utils.CLASSES.contains(c.getType())) {
+                switch (c.getType().getSimpleName()) {
+                    case "Integer":
+                        mapMessage.setInt(c.getKey(), (Integer) c.getValue());
+                        break;
+                    case "Long":
+                        mapMessage.setLong(c.getKey(), (Long) c.getValue());
+                        break;
+                    case "Float":
+                        mapMessage.setFloat(c.getKey(), (Float) c.getValue());
+                        break;
+                    case "Double":
+                        mapMessage.setDouble(c.getKey(), (Double) c.getValue());
+                        break;
+                    case "Boolean":
+                        mapMessage.setBoolean(c.getKey(), (Boolean) c.getValue());
+                        break;
+                    case "String":
+                        mapMessage.setString(c.getKey(), (String) c.getValue());
+                        break;
+                    default:
+                        LOG.error("Sending unknown type element!");
+                        mapMessage.setObject(c.getKey(), c.getValue());
+                        break;
+                }
+                mapMessage.setObject(c.getKey(), c.getValue());
+
+            } else {
+                throw new MessagingException("Unknown data type in message Content. Do not know how to send it. Type=" + c.getType());
+            }
+        }
+    }
+}

--- a/jakartalib/src/main/java/com/redhat/mqe/lib/message/MessageProvider.java
+++ b/jakartalib/src/main/java/com/redhat/mqe/lib/message/MessageProvider.java
@@ -1,0 +1,303 @@
+/*
+ * Copyright (c) 2018 Red Hat, Inc.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.redhat.mqe.lib.message;
+
+import com.redhat.mqe.lib.ClientOptionManager;
+import com.redhat.mqe.lib.ClientOptions;
+import com.redhat.mqe.lib.Content;
+import com.redhat.mqe.lib.Utils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import jakarta.jms.Destination;
+import jakarta.jms.JMSException;
+import jakarta.jms.Message;
+import jakarta.jms.Session;
+import java.io.*;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.security.InvalidParameterException;
+import java.util.List;
+
+public class MessageProvider implements AutoCloseable {
+    static Logger LOG = LoggerFactory.getLogger(MessageProvider.class);
+    private final ClientOptions senderOptions;
+    private final Session session;
+
+    public MessageProvider(ClientOptions senderOptions, Session session) {
+        this.senderOptions = senderOptions;
+        this.session = session;
+    }
+
+    /**
+     * Read binary content from file
+     *
+     * @param binaryFileName binary file to be read from
+     * @return read Byte array from file
+     */
+    protected static byte[] readBinaryContentFromFile(String binaryFileName) {
+        File binaryFile = new File(binaryFileName);
+        byte[] data = new byte[0];
+        if (binaryFile.canRead()) {
+            try {
+                data = Files.readAllBytes(binaryFile.toPath());
+            } catch (IOException e) {
+                e.printStackTrace();
+                System.exit(2);
+            }
+        } else {
+            LOG.error("Unable to access file " + binaryFileName);
+            System.exit(2);
+        }
+        LOG.debug("ToSend=" + data.length);
+        return data;
+    }
+
+    public Message provideMessage(long msgCounter) throws JMSException {
+        throw new UnsupportedOperationException("Subclass responsibility");
+    }
+
+    Message createTypedMessage() throws JMSException {
+        throw new UnsupportedOperationException("Subclass responsibility");
+    }
+
+    Message createMessage() throws JMSException {
+        Message message = createTypedMessage();
+        setMessageProperties(message);
+        setCustomMessageProperties(message);
+        return message;
+    }
+
+    /**
+     * Method creates message provider based on provided content on given session.
+     *
+     * @return newly created and set up message to be sent
+     */
+    public MessageProvider newInstance() {
+        MessageProvider provider;
+        if (hasParsedValue(ClientOptions.MSG_CONTENT_BINARY)) {
+            provider = new BytesMessageProvider(senderOptions, session);
+        } else if (hasParsedValue(ClientOptions.MSG_CONTENT, ClientOptions.MSG_CONTENT_FROM_FILE)) {
+            final String contentType = senderOptions.getOption(ClientOptions.CONTENT_TYPE).getValue().toLowerCase();
+            switch (contentType) {
+                case "string":
+                    provider = new TextMessageProvider(senderOptions, session);
+                    break;
+                case "object":
+                case "int":
+                case "integer":
+                case "long":
+                case "float":
+                case "double":
+                case "bool":
+                    provider = new ObjectMessageProvider(senderOptions, session);
+                    break;
+                default:
+                    throw new InvalidParameterException("Message content type of " + contentType + " is not supported.");
+            }
+        } else if (hasParsedValue(ClientOptions.MSG_CONTENT_LIST_ITEM)) {
+            provider = new StreamMessageProvider(senderOptions, session);
+        } else if (hasParsedValue(ClientOptions.MSG_CONTENT_MAP_ITEM)) {
+            provider = new MapMessageProvider(senderOptions, session);
+        } else {
+            LOG.trace("Unknown type of message should be created! Sending empty Message");
+            provider = new EmptyMessageProvider(senderOptions, session);
+        }
+        return provider;
+    }
+
+    /**
+     * Checks if each option hasParsedValue and ||s the results together
+     */
+    private boolean hasParsedValue(String... options) {
+        boolean result = false;
+        for (String option : options) {
+            result |= senderOptions.getOption(option).hasParsedValue();
+        }
+        return result;
+    }
+
+    String globalContentType() {
+        if (senderOptions.getOption(ClientOptions.CONTENT_TYPE).hasParsedValue()) {
+            return senderOptions.getOption(ClientOptions.CONTENT_TYPE).getValue().toLowerCase();
+        }
+        return null;
+    }
+
+    /**
+     * Set various JMS (header) properties for this message.
+     *
+     * @param message to set properties for
+     * @return same message with updated properties
+     */
+    Message setMessageProperties(Message message) {
+        try {
+            // Set message ID if provided or use default one
+            if (senderOptions.getOption(ClientOptions.MSG_ID).hasParsedValue()) {
+                final String id = senderOptions.getOption(ClientOptions.MSG_ID).getValue();
+                // producer.setDisableMessageID(true) is called elsewhere
+                if (!id.equals("noid")) {
+                    message.setJMSMessageID(id);
+                }
+            }
+            // Set message Correlation ID
+            if (senderOptions.getOption(ClientOptions.MSG_CORRELATION_ID).hasParsedValue()) {
+                message.setJMSCorrelationID(senderOptions.getOption(ClientOptions.MSG_CORRELATION_ID).getValue());
+            }
+            // Set message User ID
+            if (senderOptions.getOption(ClientOptions.MSG_USER_ID).hasParsedValue()) {
+                message.setStringProperty("JMSXUserID", senderOptions.getOption(ClientOptions.MSG_USER_ID).getValue());
+            }
+            // Set message Subject
+            if (senderOptions.getOption(ClientOptions.MSG_SUBJECT).hasParsedValue()) {
+                // FIXME? message.setJMSType(senderOptions.getOption(ClientOptions.MSG_SUBJECT).getValue());
+                message.setStringProperty("JMS_AMQP_Subject", senderOptions.getOption(ClientOptions.MSG_SUBJECT).getValue());
+            }
+            // Set message reply to destination
+            if (senderOptions.getOption(ClientOptions.MSG_REPLY_TO).hasParsedValue()) {
+                String name = senderOptions.getOption(ClientOptions.MSG_REPLY_TO).getValue();
+                Destination destination;
+                if (name.startsWith(ClientOptionManager.QUEUE_PREFIX)) {
+                    destination = session.createQueue(name.substring(ClientOptionManager.QUEUE_PREFIX.length()));
+                } else if (name.startsWith(ClientOptionManager.TOPIC_PREFIX)) {
+                    destination = session.createTopic(name.substring(ClientOptionManager.TOPIC_PREFIX.length()));
+                } else {
+                    destination = session.createQueue(name);
+                }
+                message.setJMSReplyTo(destination);
+            }
+
+            // Set message type to message content type (some JMS vendors use this internally)
+            if (senderOptions.getOption(ClientOptions.MSG_CONTENT_TYPE).hasParsedValue()) {
+                message.setStringProperty("JMS_AMQP_ContentType", senderOptions.getOption(ClientOptions.MSG_CONTENT_TYPE).getValue());
+            }
+            // Set message priority (4 by default)
+            if (senderOptions.getOption(ClientOptions.MSG_PRIORITY).hasParsedValue()) {
+                message.setJMSPriority(Integer.parseInt(senderOptions.getOption(ClientOptions.MSG_PRIORITY).getValue()));
+            }
+
+            // Set the group the message belongs to
+            if (senderOptions.getOption(ClientOptions.MSG_GROUP_ID).hasParsedValue()) {
+                message.setStringProperty("JMSXGroupID", senderOptions.getOption(ClientOptions.MSG_GROUP_ID).getValue());
+            }
+            // Set relative position of this message within its group
+            if (senderOptions.getOption(ClientOptions.MSG_GROUP_SEQ).hasParsedValue()) {
+                message.setIntProperty("JMSXGroupSeq", Integer.parseInt(senderOptions.getOption(ClientOptions.MSG_GROUP_SEQ).getValue()));
+            }
+
+            // JMS AMQP specific reply-to-group-id mapping
+            if (senderOptions.getOption(ClientOptions.MSG_REPLY_TO_GROUP_ID).hasParsedValue()) {
+                message.setStringProperty("JMS_AMQP_ReplyToGroupID", senderOptions.getOption(ClientOptions.MSG_REPLY_TO_GROUP_ID).getValue());
+            }
+
+        } catch (JMSException e) {
+            e.printStackTrace();
+        }
+        return message;
+    }
+
+    /**
+     * Set custom property values in the JMS header/body.
+     * Setting is done using reflection on Message object and invoking
+     * appropriate setXProperty(String, <primitive-type>).
+     *
+     * @param message message to have properties updated
+     */
+    void setCustomMessageProperties(Message message) {
+        String globalPropertyType = null;
+        if (senderOptions.getOption(ClientOptions.PROPERTY_TYPE).hasParsedValue()) {
+            globalPropertyType = senderOptions.getOption(ClientOptions.PROPERTY_TYPE).getValue();
+        }
+        if (senderOptions.getOption(ClientOptions.MSG_PROPERTY).hasParsedValue()) {
+            List<String> customProperties = senderOptions.getOption(ClientOptions.MSG_PROPERTY).getParsedValuesList();
+            for (String property : customProperties) {
+                // Create new 'content' object for property key=value mapping. It is same as Message Content Map, so we can safely reuse
+                Content propertyContent = new Content(globalPropertyType, property, true);
+                try {
+                    String simpleName = propertyContent.getType().getSimpleName();
+                    if (simpleName.equals("Integer")) {
+                        simpleName = "Int";
+                    }
+                    // Call the appropriate setXProperty(String, <primitive-type>) - complicated with primitive types..
+                    LOG.trace("calling method \"set" + simpleName + "Property()\" for " + property);
+                    Method messageSetXPropertyMethod = Message.class.getMethod("set" + simpleName + "Property",
+                        String.class, Utils.getPrimitiveClass(propertyContent.getType()));
+                    messageSetXPropertyMethod.invoke(message, propertyContent.getKey(), propertyContent.getValue());
+                } catch (NoSuchMethodException | InvocationTargetException | IllegalAccessException e) {
+                    LOG.error("Unable to set message property from provided input. Exiting.");
+                    e.printStackTrace();
+                    System.exit(2);
+                }
+            }
+        }
+    }
+
+    /**
+     * Create message content based on provided input.
+     * This method does not care about types. Creation of object Content
+     * takes care of autotype-casting and setting the proper values.
+     *
+     * @return message content, of some type
+     */
+    Object messageContent() {
+        if (senderOptions.getOption(ClientOptions.MSG_CONTENT).hasParsedValue()) {
+            LOG.trace("set MSG_CONTENT");
+            return senderOptions.getOption(ClientOptions.MSG_CONTENT).getValue();
+        } else if (senderOptions.getOption(ClientOptions.MSG_CONTENT_FROM_FILE).hasParsedValue()) {
+            LOG.trace("set MSG_CONTENT_FROM_FILE");
+            final String fileName = senderOptions.getOption(ClientOptions.MSG_CONTENT_FROM_FILE).getValue();
+
+            if (Boolean.parseBoolean(senderOptions.getOption(ClientOptions.MSG_CONTENT_STREAM).getValue())) {
+                File binaryFile = new File(fileName);
+                try {
+                    return new BufferedInputStream(new FileInputStream(binaryFile));
+                } catch (FileNotFoundException e) {
+                    e.printStackTrace();
+                    System.exit(3);
+                }
+            }
+
+            byte[] bytes = readBinaryContentFromFile(fileName);
+            if (Boolean.parseBoolean(senderOptions.getOption(ClientOptions.MSG_CONTENT_BINARY).getValue())) {
+                return bytes;
+            } else {
+                return new String(bytes, StandardCharsets.UTF_8);
+            }
+        }
+        throw new AssertionError("This should never be thrown");
+    }
+
+    /**
+     * Returns whether the list of Strings is empty.
+     *
+     * @param values list to be checked for emptiness
+     * @return true if the list is empty, false otherwise
+     */
+    static boolean isEmptyMessage(List<String> values) {
+        return (values.size() == 1
+            && (values.get(0).equals("") || values.get(0).equals("\"\"") || values.get(0).equals("\'\'")));
+    }
+
+    @Override
+    public void close() throws Exception {
+    }
+}

--- a/jakartalib/src/main/java/com/redhat/mqe/lib/message/ObjectMessageProvider.java
+++ b/jakartalib/src/main/java/com/redhat/mqe/lib/message/ObjectMessageProvider.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2018 Red Hat, Inc.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.redhat.mqe.lib.message;
+
+import com.redhat.mqe.lib.ClientOptions;
+import com.redhat.mqe.lib.Content;
+
+import jakarta.jms.JMSException;
+import jakarta.jms.ObjectMessage;
+import jakarta.jms.Session;
+import java.io.Serializable;
+
+public class ObjectMessageProvider extends MessageProvider {
+    private final Session session;
+
+    public ObjectMessageProvider(ClientOptions senderOptions, Session session) {
+        super(senderOptions, session);
+        this.session = session;
+    }
+
+    @Override
+    public ObjectMessage provideMessage(long msgCounter) throws JMSException {
+        return (ObjectMessage) createMessage();
+    }
+
+    @Override
+    ObjectMessage createTypedMessage() throws JMSException {
+        LOG.debug("Filling object data");
+        final Content content = new Content(globalContentType(), (String) messageContent(), false);
+
+        ObjectMessage objectMessage = session.createObjectMessage();
+        objectMessage.setObject((Serializable) content.getValue());
+        return objectMessage;
+    }
+}

--- a/jakartalib/src/main/java/com/redhat/mqe/lib/message/StreamMessageProvider.java
+++ b/jakartalib/src/main/java/com/redhat/mqe/lib/message/StreamMessageProvider.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2018 Red Hat, Inc.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.redhat.mqe.lib.message;
+
+import com.redhat.mqe.lib.ClientOptions;
+import com.redhat.mqe.lib.Content;
+
+import jakarta.jms.JMSException;
+import jakarta.jms.Session;
+import jakarta.jms.StreamMessage;
+import java.util.List;
+
+public class StreamMessageProvider extends MessageProvider {
+    private final ClientOptions senderOptions;
+    private final Session session;
+
+    public StreamMessageProvider(ClientOptions senderOptions, Session session) {
+        super(senderOptions, session);
+        this.senderOptions = senderOptions;
+        this.session = session;
+    }
+
+    @Override
+    public StreamMessage provideMessage(long msgCounter) throws JMSException {
+        return (StreamMessage) createMessage();
+    }
+
+    @Override
+    StreamMessage createTypedMessage() throws JMSException {
+        LOG.trace("set MSG_CONTENT_LIST_ITEM");
+
+        // Create "ListMessage" using StreamMessage
+        StreamMessage message = session.createStreamMessage();
+
+        List<String> values = senderOptions.getOption(ClientOptions.MSG_CONTENT_LIST_ITEM).getParsedValuesList();
+        if (isEmptyMessage(values)) {
+            return message;
+        }
+        for (String parsedItem : values) {
+            Content content = new Content(globalContentType(), parsedItem, false);
+            message.writeObject(content.getValue());
+        }
+        return message;
+    }
+}

--- a/jakartalib/src/main/java/com/redhat/mqe/lib/message/TextMessageProvider.java
+++ b/jakartalib/src/main/java/com/redhat/mqe/lib/message/TextMessageProvider.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2018 Red Hat, Inc.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.redhat.mqe.lib.message;
+
+import com.redhat.mqe.lib.ClientOptions;
+import com.redhat.mqe.lib.Content;
+
+import jakarta.jms.JMSException;
+import jakarta.jms.Session;
+import jakarta.jms.TextMessage;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class TextMessageProvider extends MessageProvider {
+    private final Session session;
+
+    private TextMessage message;
+    private boolean userMessageCounter = false;
+    private String userMessageCounterText;
+
+    public TextMessageProvider(ClientOptions senderOptions, Session session) {
+        super(senderOptions, session);
+        this.session = session;
+    }
+
+    @Override
+    public TextMessage provideMessage(long msgCounter) throws JMSException {
+        if (message == null) {
+            message = (TextMessage) createMessage();
+        }
+        if (userMessageCounter) {
+            ((TextMessage) message).setText(String.format(userMessageCounterText, msgCounter));
+        }
+        return message;
+    }
+
+    TextMessage createTypedMessage() throws JMSException {
+        LOG.trace("set MSG_CONTENT");
+        final Content content = new Content(globalContentType(), (String) messageContent(), false);
+
+        TextMessage textMessage = session.createTextMessage();
+        String textContent = content.getValue().toString();
+        String pattern = "%[ 0-9]*d";
+        Pattern r = Pattern.compile(pattern);
+        Matcher matcher = r.matcher(textContent);
+
+        if (matcher.find()) {
+            userMessageCounter = true;
+            userMessageCounterText = textContent;
+        }
+        textMessage.setText(textContent);
+        return textMessage;
+    }
+}

--- a/jakartalib/src/test/java/com/redhat/mqe/lib/FakeClient.java
+++ b/jakartalib/src/test/java/com/redhat/mqe/lib/FakeClient.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2022 Red Hat, Inc.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.redhat.mqe.lib;
+
+import com.redhat.mqe.ClientListener;
+import dagger.Binds;
+import dagger.BindsInstance;
+import dagger.Component;
+import dagger.Module;
+import org.jetbrains.annotations.Nullable;
+
+import javax.inject.Named;
+
+
+@Component(modules = {FakeClientModule.class})
+interface FakeClient extends Client {
+    ConnectionManagerFactory fakeConnectionManagerFactory();
+
+    @Component.Builder
+    abstract class Builder {
+        @BindsInstance
+        abstract Builder connectionManagerFactory(ConnectionManagerFactory f);
+
+        @BindsInstance
+        abstract Builder messageFormatter(JmsMessageFormatter f);
+
+        @BindsInstance
+        abstract Builder clientOptionManager(ClientOptionManager m);
+
+        @BindsInstance
+        abstract Builder args(@Args String[] args);
+
+        @BindsInstance
+        abstract Builder listener(@Nullable ClientListener listener);
+
+        abstract FakeClient build();
+    }
+}
+
+@Module(includes = FakeClientModule.Declarations.class)
+class FakeClientModule {
+    @Module
+    interface Declarations {
+        @Binds
+        @Named("Sender")
+        ClientOptions bindClientOptions(SenderOptions o);
+
+        @Binds
+        @Named("Receiver")
+        ClientOptions bindReceiverOptions(ReceiverOptions o);
+
+        @Binds
+        @Named("Connector")
+        ClientOptions bindConnectorOptions(ConnectorOptions o);
+    }
+}

--- a/jakartalib/src/test/kotlin/MainTest.kt
+++ b/jakartalib/src/test/kotlin/MainTest.kt
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2022 Red Hat, Inc.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import org.junit.jupiter.api.Test
+
+class MainTest {
+    @Test
+    fun notEnoughArguments_0() {
+//        exit.expectSystemExitWithStatus(1)
+//        Main.main(emptyArray<String>(), null, null)
+    }
+
+    @Test
+    fun notEnoughArguments_1() {
+//        Main.main(arrayOf("sender"), null, null) // should somehow break, NPE probably
+    }
+
+    @Test
+    fun wrongArgument() {
+//        Main.main(arrayOf("aString"), null, null) // should exit(1)
+    }
+}

--- a/jakartalib/src/test/kotlin/com/redhat/mqe/lib/AbstractJmsMessageFormatterTest.kt
+++ b/jakartalib/src/test/kotlin/com/redhat/mqe/lib/AbstractJmsMessageFormatterTest.kt
@@ -23,8 +23,8 @@ import com.google.common.truth.Truth.assertThat
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.function.Executable
-import javax.jms.BytesMessage
-import javax.jms.Message
+import jakarta.jms.BytesMessage
+import jakarta.jms.Message
 
 class JmsFormatter : JmsMessageFormatter() {
     override fun formatMessage(msg: Message, hashContent: Boolean): MutableMap<String, Any>? {
@@ -40,8 +40,8 @@ abstract class AbstractJmsMessageFormatterTest {
     @Test
     fun `format content of empty bytes message`() {
         val bytesMessage = getBytesMessage()
-        bytesMessage.reset()
-        assertThat(formatter.formatContent(bytesMessage)).isNull()
+         bytesMessage.reset()
+        assertThat(formatter.formatContent(bytesMessage as Message?)).isNull()
     }
 
     @Test

--- a/jakartalib/src/test/kotlin/com/redhat/mqe/lib/InteractionTest.kt
+++ b/jakartalib/src/test/kotlin/com/redhat/mqe/lib/InteractionTest.kt
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2022 Red Hat, Inc.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.redhat.mqe.lib
+
+import com.redhat.mqe.lib.Main.main
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.BDDMockito.given
+import org.mockito.Mock
+import org.mockito.Mockito.*
+import org.mockito.MockitoAnnotations
+import jakarta.jms.*
+
+class InteractionTest {
+    @Mock
+    lateinit var message: Message
+    @Mock
+    lateinit var producer: MessageProducer
+    @Mock
+    lateinit var consumer: MessageConsumer
+    @Mock
+    lateinit var session: Session
+    @Mock
+    lateinit var connection: Connection
+    @Mock
+    lateinit var connectionManager: ConnectionManager
+    @Mock
+    lateinit var connectionManagerFactory: ConnectionManagerFactory
+
+    @BeforeEach
+    fun setUpMocks() {
+        MockitoAnnotations.initMocks(this)
+
+        given(consumer.receive(anyLong()))
+            .willReturn(message, null)
+
+        given(session.createProducer(any(Destination::class.java)))
+            .willReturn(producer)
+        given(session.createProducer(null))
+            .willReturn(producer)
+        given(session.createMessage()).willReturn(message)
+        given(session.createConsumer(isNull(), anyString(), anyBoolean()))
+            .willReturn(consumer)
+
+        given(connection.createSession(anyBoolean(), anyInt()))
+            .willReturn(session)
+        given(connectionManager.getConnection()).willReturn(connection)
+        given(connectionManagerFactory.make(any(ClientOptions::class.java), anyString()))
+            .willReturn(connectionManager)
+    }
+
+    @Test
+    fun `test run sender no params`() {
+        val args = arrayOf("sender")
+        val client = createFakeClient(args)
+
+        main(args, client)  // or client.makeSenderClient().startClient()
+
+        verify(producer, times(1)).send(message)
+    }
+
+    @Test
+    fun `test run receiver no params`() {
+        val args = arrayOf("receiver")
+        val client = createFakeClient(args)
+
+        main(args, client)  // or client.makeSenderClient().startClient()
+
+        verify(consumer, times(2)).receive(anyLong())
+    }
+
+    private fun createFakeClient(args: Array<String>): FakeClient {
+        return DaggerFakeClient.builder()
+            .connectionManagerFactory(connectionManagerFactory)
+            .messageFormatter(mock(JmsMessageFormatter::class.java))
+            .clientOptionManager(mock(ClientOptionManager::class.java))
+            .args(args)
+            .build()
+    }
+}

--- a/jakartalib/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/jakartalib/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline

--- a/jmslib/pom.xml
+++ b/jmslib/pom.xml
@@ -63,4 +63,22 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <!-- https://stackoverflow.com/questions/174560/sharing-test-code-in-maven#174670 -->
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>${plugin.jar.version}</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>test-jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
 </project>

--- a/jmslib/pom.xml
+++ b/jmslib/pom.xml
@@ -62,6 +62,11 @@
             <artifactId>mockito-core</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.google.truth</groupId>
+            <artifactId>truth</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/jmslib/src/test/kotlin/com/redhat/mqe/lib/AbstractJmsMessageFormatterTest.kt
+++ b/jmslib/src/test/kotlin/com/redhat/mqe/lib/AbstractJmsMessageFormatterTest.kt
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2017 Red Hat, Inc.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.redhat.mqe.lib
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.function.Executable
+import javax.jms.BytesMessage
+import javax.jms.Message
+
+class JmsFormatter : JmsMessageFormatter() {
+    override fun formatMessage(msg: Message, hashContent: Boolean): MutableMap<String, Any>? {
+        TODO("not implemented")
+    }
+}
+
+abstract class AbstractJmsMessageFormatterTest {
+    private val formatter = JmsFormatter()
+
+    abstract fun getBytesMessage(): BytesMessage
+
+    @Test
+    fun `format content of empty bytes message`() {
+        val bytesMessage = getBytesMessage()
+         bytesMessage.reset()
+        assertThat(formatter.formatContent(bytesMessage as Message?)).isNull()
+    }
+
+    @Test
+    fun `test python formatString`() {
+        val assertions = listOf(
+            "" to "''",
+            "a" to "'a'",
+            "\"" to "'\"'",
+            "'" to "'\\''"
+//            "\\" to "'\\\\'" // FIXME: does not work
+        )
+        Assertions.assertAll(assertions.map {
+            Executable {
+                assertThat(formatter.formatString(it.first).toString()).isEqualTo(it.second)
+            }
+        }.stream())
+    }
+}

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -244,6 +244,8 @@
                     <compilerArgument>-Xlint:all</compilerArgument>
                     <showWarnings>true</showWarnings>
                     <showDeprecation>true</showDeprecation>
+                    <!--javac provides meaningful error messages-->
+                    <forceJavacCompilerUse>true</forceJavacCompilerUse>
                     <annotationProcessorPaths>
                         <path>
                             <groupId>com.google.dagger</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -41,6 +41,7 @@
 
         <module>lib</module>
         <module>jmslib</module>
+        <module>jakartalib</module>
 
         <module>cli</module>
         <module>cli-activemq</module>


### PR DESCRIPTION
The idea is to clone `jmslib` into `jakartalib` and use that in cli-qpid-jms. Eventually, all libs will migrate to the jakarta api.