### PR TITLE
[protonj2] Add `--conn-reconnect` to sender and receiver

### DIFF
--- a/cli-protonj2/src/main/java/com/redhat/mqe/CliProtonJ2Receiver.java
+++ b/cli-protonj2/src/main/java/com/redhat/mqe/CliProtonJ2Receiver.java
@@ -118,7 +118,7 @@ public class CliProtonJ2Receiver extends CliProtonJ2SenderReceiver implements Ca
     private String msgContentToFile;
 
     @CommandLine.Option(names = {"--conn-reconnect"})
-    private boolean reconnect = false;
+    private String reconnectString = "false";
 
     public CliProtonJ2Receiver() {
         this.messageFormatter = new ProtonJ2MessageFormatter();
@@ -166,7 +166,9 @@ public class CliProtonJ2Receiver extends CliProtonJ2SenderReceiver implements Ca
         }
 
         final ConnectionOptions options = new ConnectionOptions();
-        options.reconnectEnabled(reconnect);
+        if (stringToBool(reconnectString)) {
+            options.reconnectEnabled(true);
+        }
         options.user(connUsername);
         options.password(connPassword);
         for (AuthMechanism mech : connAuthMechanisms) {

--- a/cli-protonj2/src/main/java/com/redhat/mqe/CliProtonJ2Receiver.java
+++ b/cli-protonj2/src/main/java/com/redhat/mqe/CliProtonJ2Receiver.java
@@ -117,6 +117,9 @@ public class CliProtonJ2Receiver extends CliProtonJ2SenderReceiver implements Ca
     @CommandLine.Option(names = {"--msg-content-to-file"})
     private String msgContentToFile;
 
+    @CommandLine.Option(names = {"--conn-reconnect"})
+    private boolean reconnect = false;
+
     public CliProtonJ2Receiver() {
         this.messageFormatter = new ProtonJ2MessageFormatter();
     }
@@ -163,6 +166,7 @@ public class CliProtonJ2Receiver extends CliProtonJ2SenderReceiver implements Ca
         }
 
         final ConnectionOptions options = new ConnectionOptions();
+        options.reconnectEnabled(reconnect);
         options.user(connUsername);
         options.password(connPassword);
         for (AuthMechanism mech : connAuthMechanisms) {

--- a/cli-protonj2/src/main/java/com/redhat/mqe/CliProtonJ2Sender.java
+++ b/cli-protonj2/src/main/java/com/redhat/mqe/CliProtonJ2Sender.java
@@ -166,7 +166,7 @@ public class CliProtonJ2Sender extends CliProtonJ2SenderReceiver implements Call
     private DurationModeSender durationMode;
 
     @CommandLine.Option(names = {"--conn-reconnect"})
-    private boolean reconnect = false;
+    private String reconnectString = "false";
 
     public CliProtonJ2Sender() {
         this.messageFormatter = new ProtonJ2MessageFormatter();
@@ -202,7 +202,9 @@ public class CliProtonJ2Sender extends CliProtonJ2SenderReceiver implements Call
         final ConnectionOptions options = new ConnectionOptions();
         // TODO typo in javadoc: This option enables or disables reconnection to a remote remote peer after IO errors. To control
         // TODO API: unclear if reconnect is on or off by default (public static final boolean DEFAULT_RECONNECT_ENABLED = false;)
-        options.reconnectEnabled(reconnect);
+        if (stringToBool(reconnectString)) {
+            options.reconnectEnabled(true);
+        }
         options.user(connUsername);
         options.password(connPassword);
         for (AuthMechanism mech : connAuthMechanisms) {

--- a/cli-protonj2/src/main/java/com/redhat/mqe/CliProtonJ2Sender.java
+++ b/cli-protonj2/src/main/java/com/redhat/mqe/CliProtonJ2Sender.java
@@ -165,6 +165,9 @@ public class CliProtonJ2Sender extends CliProtonJ2SenderReceiver implements Call
     @CommandLine.Option(names = {"--duration-mode"})
     private DurationModeSender durationMode;
 
+    @CommandLine.Option(names = {"--conn-reconnect"})
+    private boolean reconnect = false;
+
     public CliProtonJ2Sender() {
         this.messageFormatter = new ProtonJ2MessageFormatter();
     }
@@ -197,6 +200,9 @@ public class CliProtonJ2Sender extends CliProtonJ2SenderReceiver implements Call
         final Client client = Client.create();
 
         final ConnectionOptions options = new ConnectionOptions();
+        // TODO typo in javadoc: This option enables or disables reconnection to a remote remote peer after IO errors. To control
+        // TODO API: unclear if reconnect is on or off by default (public static final boolean DEFAULT_RECONNECT_ENABLED = false;)
+        options.reconnectEnabled(reconnect);
         options.user(connUsername);
         options.password(connPassword);
         for (AuthMechanism mech : connAuthMechanisms) {
@@ -288,7 +294,7 @@ public class CliProtonJ2Sender extends CliProtonJ2SenderReceiver implements Call
                 sender.send(message);  // TODO what's timeout for in a sender?
 
                 Map<String, Object> messageDict = messageFormatter.formatMessage(address, (Message<Object>) message, stringToBool(msgContentHashedString));
-                switch(out) {
+                switch (out) {
                     case python:
                         switch (logMsgs) {
                             case dict:


### PR DESCRIPTION
This works, except for handling connection:forced. Afaik I can't do anything about it.

The test that fails due to this is JAMQConnectioniiiTests/test_client_reconnect_msgsrv_sigterm, see https://github.com/rh-messaging/cli-java/issues/451 for future updates on this.