### PR TITLE
Fixes #484: Do not use non-numeric UID in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,3 @@ COPY cli-paho-java/target/cli-paho-java-1.2.2-SNAPSHOT-*.jar /main/cli-paho.jar
 
 COPY create_links.sh /main
 RUN bash /main/create_links.sh
-
-
-RUN groupadd cli-java && useradd -d /var/lib/cli-java -ms /bin/bash -g cli-java -G cli-java cli-java
-USER cli-java:cli-java


### PR DESCRIPTION
It appears that not setting USER at all will take care of this.

Original issue https://github.com/rh-messaging/shipshape/pull/75