### PR TITLE
Issue #577: Revert "Bump activemq-client from 5.17.4 to 5.18.0"

### DIFF
--- a/cli-activemq/pom.xml
+++ b/cli-activemq/pom.xml
@@ -35,7 +35,7 @@
     <properties>
         <bundle.symbolic.name.suffix>aoc</bundle.symbolic.name.suffix>
         <jar.main.class>com.redhat.mqe.aoc.Main</jar.main.class>
-        <activemq.client.version>5.18.0</activemq.client.version>
+        <activemq.client.version>5.17.4</activemq.client.version>
         <library.version>${activemq.client.version}</library.version>
     </properties>
 


### PR DESCRIPTION
Reverts rh-messaging/cli-java#569