### PR TITLE
Update qpid.jms.client.version and add new repository

### DIFF
--- a/cli-qpid-jms/pom.xml
+++ b/cli-qpid-jms/pom.xml
@@ -35,12 +35,19 @@
     <properties>
         <bundle.symbolic.name.suffix>jms</bundle.symbolic.name.suffix>
         <jar.main.class>com.redhat.mqe.jms.Main</jar.main.class>
-        <qpid.jms.client.version>2.3.0</qpid.jms.client.version>
+        <qpid.jms.client.version>2.4.0</qpid.jms.client.version>
         <library.version>${qpid.jms.client.version}</library.version>
         <tcnative.version>2.0.61.Final</tcnative.version>
         <tcnative.classifier>linux-x86_64-fedora</tcnative.classifier>
         <jaeger-client.version>1.8.1</jaeger-client.version>
     </properties>
+
+    <repositories>
+        <repository>
+            <id>staging</id>
+            <url>https://repository.apache.org/content/repositories/orgapacheqpid-1263</url>
+        </repository>
+    </repositories>
 
     <dependencyManagement>
         <dependencies>


### PR DESCRIPTION
The qpid.jms.client.version in cli-qpid-jms/pom.xml file has been updated from 2.3.0 to 2.4.0 to incorporate the latest updates and features of the JMS client. In addition to this, a new repository from https://repository.apache.org/content/repositories/orgapacheqpid-1263 has been added to access newer dependencies.