### PR TITLE
Update protonj2 version and add staging repository

### DIFF
--- a/cli-protonj2/pom.xml
+++ b/cli-protonj2/pom.xml
@@ -34,13 +34,20 @@
 
     <properties>
         <bundle.symbolic.name.suffix>jms</bundle.symbolic.name.suffix>
-        <protonj2.version>1.0.0-M15</protonj2.version>
+        <protonj2.version>1.0.0-M16</protonj2.version>
         <jar.main.class>com.redhat.mqe.Main</jar.main.class>
         <library.version>${protonj2.version}</library.version>
         <tcnative.version>2.0.39.Final</tcnative.version>
         <tcnative.classifier>linux-x86_64-fedora</tcnative.classifier>
         <jaeger-client.version>1.6.0</jaeger-client.version>
     </properties>
+
+    <repositories>
+        <repository>
+            <id>staging</id>
+            <url>https://repository.apache.org/content/repositories/orgapacheqpid-1261</url>
+        </repository>
+    </repositories>
 
     <!--TODO: find out correct tcnative version to be used here (depends on version of netty)-->
 


### PR DESCRIPTION
This commit updates protonj2 version from 1.0.0-M15 to 1.0.0-M16. Additionally, a new repository URL is added to the repositories list. The protonj2 version is updated to avail the newer features and to fix potential bugs. Adding the repository URL to project POM offers a location to download dependency during the build.