### PR TITLE
fix hivemq-mqtt on multiplatforms

### DIFF
--- a/image/bin/cli-hivemq-mqtt-publish
+++ b/image/bin/cli-hivemq-mqtt-publish
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+java ${JAVA_OPTS} ${CLI_ACTIVEMQ_OPTS} -jar /opt/cli-java/cli-hivemq-mqtt.jar publish "$@"

--- a/image/bin/cli-hivemq-mqtt-subscribe
+++ b/image/bin/cli-hivemq-mqtt-subscribe
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+java ${JAVA_OPTS} ${CLI_ACTIVEMQ_OPTS} -jar /opt/cli-java/cli-hivemq-mqtt.jar subscribe "$@"

--- a/image/bin/cli-mqtt-publish
+++ b/image/bin/cli-mqtt-publish
@@ -1,3 +1,0 @@
-#!/bin/sh
-
-java ${JAVA_OPTS} ${CLI_ACTIVEMQ_OPTS} -jar /opt/cli-java/cli-mqtt.jar publish $@

--- a/image/bin/cli-mqtt-subscribe
+++ b/image/bin/cli-mqtt-subscribe
@@ -1,3 +1,0 @@
-#!/bin/sh
-
-java ${JAVA_OPTS} ${CLI_ACTIVEMQ_OPTS} -jar /opt/cli-java/cli-mqtt.jar subscribe $@


### PR DESCRIPTION
- use hivemq-mqtt jar instead of build it as gradle fails on ppc64le and I was not able to find the reason
- update the name of the cli command to be cli-hivemq-mqtt to match the pattern of other cli tools.
- update the FROM to use the ARG variables 